### PR TITLE
Introducing Dashboard Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ good overview of the SignalFx API consult the [upstream documentation][sfxdocs].
       - [Building Charts](#charts)
       - [Building Dashboards](#dashboards)
       - [Updating Dashboards](#dashboards-updates)
+      - [Dashboard Filters](#dashboard-filters)
       - [Creating Detectors](#detectors)
           - [Building Detectors from Existing Charts](#from_chart)
       - [Using Flow and Combinator Functions In Formulas](#flow)
@@ -232,6 +233,47 @@ dash.update(
 
 `Dashboard` updates will also update any `Chart` configurations it owns.
 
+    Note: If the given dashboard does not already exist, `update` will create a new dashboard for you
+
+<a name="dashboard-filters"></a>
+### Providing Dashboard Filters
+
+Dashboards can be configured to provide various filters that affect the behavior of all configured charts (overriding any conflicting filters at the chart level). You may wish to do this in order to quickly change the environment that you're observing for a given set of charts.
+
+
+```python
+from signal_analog.filters import DashboardFilters, FilterVariable
+app_var = FilterVariable().with_alias('app')\
+.with_property('app')\
+.with_is_required(True)\
+.with_value('foo')
+
+env_var = FilterVariable().with_alias('env')\
+.with_property('env')\
+.with_is_required(True)\
+.with_value('prod')
+
+app_filter = DashboardFilters() \
+.with_variables(app_var, env_var)
+```
+So, here we are creating a couple of filters "app=foo" and "env=prod".
+Now we can pass this config to a dashboard object:
+
+```python
+response = dash\
+.with_charts(memory_chart)\
+.with_api_token('my-api-token')\
+.with_filters(app_filter)\
+.create()
+```
+
+If you are updating an existing dashboard:
+
+```python
+response = dash\
+.with_filters(app_filter)\
+.update()
+```
 <a name="detectors"></a>
 ### Creating Detectors
 

--- a/signal_analog/filters.py
+++ b/signal_analog/filters.py
@@ -1,0 +1,73 @@
+import signal_analog.util as util
+
+
+class FilterVariable(object):
+
+    def __init__(self):
+        self.options = {}
+
+    def with_alias(self, alias):
+        util.is_valid(alias, error_message='"alias" cannot be empty', expected_type=str)
+        self.options.update({'alias': alias})
+        return self
+
+    def with_apply_if_exists(self, apply_if_exists):
+        util.is_valid(apply_if_exists, expected_type=bool)
+        self.options.update({'apply_if_exists': apply_if_exists})
+        return self
+
+    def with_description(self, description):
+        self.options.update({'description': description})
+        return self
+
+    def with_preferred_suggestions(self, *preferred_suggestions):
+        self.options.update({'preferredSuggestions': []})
+        for preferred_suggestion in preferred_suggestions:
+            self.options['preferredSuggestions'].append(preferred_suggestion)
+        return self
+
+    def with_property(self, property):
+        util.is_valid(property, error_message='"property" cannot be empty', expected_type=str)
+        self.options.update({'property': property})
+        return self
+
+    def with_replace_only(self, replace_only):
+        util.is_valid(replace_only, expected_type=bool)
+        self.options.update({'replaceOnly': replace_only})
+        return self
+
+    def with_is_required(self, required):
+        util.is_valid(required, expected_type=bool)
+        self.options.update({'required': required})
+        return self
+
+    def with_is_restricted(self, restricted):
+        util.is_valid(restricted, expected_type=bool)
+        self.options.update({'restricted': restricted})
+        return self
+
+    def with_value(self, *values):
+        self.options.update({'value': []})
+        for value in values:
+            self.options['value'].append(value)
+        return self
+
+
+class DashboardFilters(object):
+    """A filters model to be attached to a dashboard."""
+
+    def __init__(self):
+        """Initialize filters object"""
+        self.options = {}
+
+    def with_variables(self, *variables):
+        self.options.update({'variables': []})
+        for variable in variables:
+            if 'alias' not in variable.options and 'property' not in variable.options:
+                raise ValueError('"alias" and "property" are required parameters')
+            elif 'alias' not in variable.options:
+                raise ValueError('"alias" is a required parameter')
+            elif 'property' not in variable.options:
+                raise ValueError('"property" is a required parameter')
+            self.options['variables'].append(variable.options)
+        return self

--- a/signal_analog/resources.py
+++ b/signal_analog/resources.py
@@ -86,12 +86,12 @@ class Resource(object):
 
     def __set_endpoint__(self, endpoint):
         """Internal helper for setting valid endpoints."""
-        util.is_valid(endpoint,  "Cannot proceed with an empty endpoint")
+        util.is_valid(endpoint,  error_message="Cannot proceed with an empty endpoint")
         self.endpoint = endpoint
 
     def __set_base_url__(self, base_url):
         """Internal helper for setting valid base_urls."""
-        util.is_valid(base_url, "Cannot proceed with empty base_url")
+        util.is_valid(base_url, error_message="Cannot proceed with empty base_url")
         self.base_url = base_url
 
     def with_api_token(self, token):

--- a/signal_analog/util.py
+++ b/signal_analog/util.py
@@ -23,11 +23,12 @@ def in_given_enum(value, enum):
         raise ValueError(msg.format(value, valid_values))
 
 
-def is_valid(value, error_message=None):
+def is_valid(value, error_message=None, expected_type=None):
     """Void method ensuring value is non-empty.
 
     Arguments:
         value: the value to check
+        expected_type: expected data type of the value. Ex: bool, str
         error_message: an optional error message to provide the user
 
     Returns:
@@ -38,6 +39,13 @@ def is_valid(value, error_message=None):
             raise ValueError(error_message)
         else:
             raise ValueError()
+    elif expected_type:
+        try:
+            if not isinstance(value, expected_type):
+                raise ValueError('Expecting a variable of type {0}. But got a {1}("{2}")'
+                                 .format(expected_type, type(value), value))
+        except TypeError:
+            raise ValueError('"{0}" is not a valid data type'.format(expected_type))
 
 
 def find_duplicates(xs):

--- a/tests/mocks/dashboard_create_with_filters_with_empty_alias_failure.json
+++ b/tests/mocks/dashboard_create_with_filters_with_empty_alias_failure.json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_with_empty_property_failure.json
+++ b/tests/mocks/dashboard_create_with_filters_with_empty_property_failure.json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_with_missing_alias_failure.json
+++ b/tests/mocks/dashboard_create_with_filters_with_missing_alias_failure.json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_with_missing_property_failure.json
+++ b/tests/mocks/dashboard_create_with_filters_with_missing_property_failure.json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_with_multiple_values_success.json
+++ b/tests/mocks/dashboard_create_with_filters_with_multiple_values_success.json
@@ -1,0 +1,215 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-04-03T17:38:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 17:38:41 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-03T17:38:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "[{\"name\": \"lol\", \"options\": {\"type\": \"TimeSeriesChart\"}, \"programText\": \"data(\\\"cpu.utilization\\\").publish()\"}]"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "111"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWQwU7DMBBE73yF5TMHUoVG5WZIKyEhtRL0UBAH42wTgxMHe9MSqv47thNogtRT5De72Zk5XBBCRcENplBZiS0lN4Sm8wVbPzzRyz/Vev5CDg78ovusm32OWbyaMsFYmPeyVk1ZefWqJwXIvEBPop4YvR8O7GWGhQdT9z6S1+6yAY4QzkTXk0mSJNEkSmazk6hN8HCnGrt6/Gab3gMVjUVdroyuwaCE4L5qlApiBlYYWaPUwSPtVjJphd6BaZdBGa/ADipcOlXxdqxspUIwgfXlWN0YMT7pKMoS/qEdN5K/qdOojx5+mhvd1MN+14zli7wzKgf8851t0rjjiltc19n5xgYDt+0ohNLio9vacmUhsJJ/peDi+tRGZiPztOJdGopgsSWl8F9Xg2s06BYUOJbNz/aGPD/lPv4ATlm3cIcCAAA=",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "332"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 17:38:41 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-03T17:38:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"maxDelayOverride\": null, \"lastUpdatedBy\": null, \"lastUpdated\": 1522777121799, \"id\": \"DZ4A4qjAYD4\", \"eventOverlays\": null, \"discoveryOptions\": null, \"groupId\": \"DZ4A4UAAgFg\", \"name\": \"testy mctesterson\", \"filters\": {\"variables\": [{\"property\": \"app\", \"required\": true, \"value\": [\"bar1\", \"bar2\"], \"alias\": \"app\"}]}, \"tags\": null, \"creator\": \"ClusPSzAYAA\", \"chartDensity\": \"DEFAULT\", \"selectedEventOverlays\": null, \"created\": 1522777121799, \"locked\": false, \"description\": \"\", \"customProperties\": null, \"charts\": [{\"chartId\": \"DZ4A4P6AcAA\", \"column\": 0, \"height\": 1, \"width\": 6, \"row\": 0}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "588"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.signalfx.com/v2/dashboard/DZ4A4qjAYD4"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSMU/DMBCF9/4KyzMDiQoRbIYWCQmplaBDQQyuc00NThzOdmmo+t9x7FCaFibL3zvrzvfedkAIFSuOdgSVkbah5JrQ0fiOzR6e6NleNS1/IVsPftB9Hmufh2w4vWSCsVDfylq5smrV846sQBYr25KkI6g/Dws+ZW5XLbj09x15jZ0RuIXQJrlI0yzLkjTJrq5+RY1hhlvlzPTxi827GahwxupyiroGtBLC9JVTKog5GIGytlKHGWl8kksj9BqwmQSl/wTWUNmJVxVv+spSKgsYWLccox2KfktPrSzhCK05Sr5Q0Nut51xJHhjldd3tlISLau6X44000Y4lVwb28tGvfvt4rUZYAiLkj64owOz/9xIX3dWEZTWnjRFqxQVMKtWctkX4cBKjSRbdoWAsStH513+05spBHIAuOCb0LJwpJa+hZBfOXVhwgdrVh1mbMVbcFdE0ecA/3th8NIxccWNndX6SnvQ8zY4Lbpq/M6S0eD8anpZ8MwKfgTYKKPOeo7Ti0WJq/dcbUor29NnwhgTdgIJ2H+N/w2R5sQeD3Tf7W9MinAMAAA==",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "433"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 17:38:41 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/DZ4A4qjAYD4"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_with_multiple_variables_success.json
+++ b/tests/mocks/dashboard_create_with_filters_with_multiple_variables_success.json
@@ -1,0 +1,215 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-04-03T17:37:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 17:37:28 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-03T17:37:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "[{\"name\": \"lol\", \"programText\": \"data(\\\"cpu.utilization\\\").publish()\", \"options\": {\"type\": \"TimeSeriesChart\"}}]"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "111"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWQwU7DMBBE73yF5TNIaVVa4GaaIiEhtRL0AKgH42wTCycO9qYlVP13bCclCVJPkd/sZmfmcEEIFRk3GENhJdaU3BEaLx7Y+umFXv6p1vN3cnDghB6TZvZtwr6u1kwwFua9rFWVF16NWpKBTDP0ZNQSo/f9gb1MMPNg6t5HsmkuG+AI4czoejyezWbR5GY6jTpRm+Bhriq7ev5hr60HKiqLOl8ZXYJBCcF9USkVxASsMLJEqYNH2qwk0gq9A1MvgzJcgR0UuHSq4vVQ2UqFYAJry7G6MmJ40lGUOfxDO24k/1DdqI8efpoaXZW9fs38lqWnbLLH46jLrLjFdZmcb6w3cF8PQigtPputLVcWAsv5dwwurk9tZDIwTwvepKEIFmuSC/91NbhGg25BgWPJ4mxvyNMu9/EXDVRq8YcCAAA=",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "329"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 17:37:28 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-03T17:37:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"created\": 1522777048660, \"name\": \"testy mctesterson\", \"description\": \"\", \"filters\": {\"variables\": [{\"value\": [\"bar\"], \"property\": \"app\", \"alias\": \"app\", \"required\": true}, {\"value\": [\"prod\"], \"property\": \"env\", \"alias\": \"env\", \"required\": true}]}, \"chartDensity\": \"DEFAULT\", \"creator\": \"ClusPSzAYAA\", \"lastUpdated\": 1522777048660, \"discoveryOptions\": null, \"id\": \"DZ4ArD0AYAA\", \"customProperties\": null, \"selectedEventOverlays\": null, \"charts\": [{\"height\": 1, \"chartId\": \"DZ4Aq-UAcAA\", \"width\": 6, \"column\": 0, \"row\": 0}], \"tags\": null, \"groupId\": \"DZ4ArC9AgAA\", \"locked\": false, \"eventOverlays\": null, \"maxDelayOverride\": null, \"lastUpdatedBy\": null}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "653"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.signalfx.com/v2/dashboard/DZ4ArD0AYAA"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAMVTQW7CMBC89xWRz1SiQIH2lgKVkCqBRDm0iINxlmDVicPaDqQVf6/jpIEAPVY9WZ5Za9azO183nkfYhqIeQqy4zoj36JHh6Nmfv7ySRsWqHF94Xxb4gcZBUfve8be3c5/5vqvPaSlMFOdss0Q2wMONzpG7EkG5Oy3Y8UBvcqBr7wdvWSgjUA1O5u6+1er1es1Ov9ttHkmJroeBMGo6+/Tfyh4IM0rLaIoyAdQcXPexEcKRASiGPNFcuh5J8STgiskUMJs4pv4EUoj1xLKCZnVmzYUGdFhpjpIGWV3SoppHcAalFDldCah5a3EqOHUYoUlSeuq5i8jG69Geq2IcayoUVPTZr446lksQ1oAIwcyEIajqf4vC6LLGmZVdCiMkgjKYxCK7lEXYGo7FkDSaU0Jp5KycX/1RSoWBogGyonaGS8ccGtdMgDj9HxNqwn9rgtUNKhfceXDbFaI0yUnQcPDghz9Lzk/wYfO4/IIqPU+Cy+j02+3zgqfseoCEZB9nTZOI7odgA5DnAHlQW2cS02K/ibZfzryI5acNhh2E4xUIyH0Y/ZokTcMKuDl8A7Y9aM+ZBAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "447"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 17:37:28 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/DZ4ArD0AYAA"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_with_one_variable_success.json
+++ b/tests/mocks/dashboard_create_with_filters_with_one_variable_success.json
@@ -1,0 +1,215 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-04-03T17:36:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 17:36:14 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-03T17:36:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "[{\"options\": {\"type\": \"TimeSeriesChart\"}, \"programText\": \"data(\\\"cpu.utilization\\\").publish()\", \"name\": \"lol\"}]"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "111"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWQzU7DMBCE7zyF5TMHWtpUcDO0SEgtrQQ9AOJg7G1i4cSRvWkbqr47ttOfBKmnyN/sZmdmd0UIFRm3OIbCKawpuSd0PHliy+kbvT6pLvBPsvPgiJ5lM/sxYNNtwt4Zi/NBNrrKi6DeHEgGKs0wkN6BWLNpD2yUxCyAxL/35Ku5bIEjxDO9Yb8/GiV3o2H/NjmLxkYPj7pyi9ffkwcqKocmX1hTgkUF0X1RaR1FCU5YVaIy0SNtVqRywqzB1vOodFdgDQXOvap53VVWSiPYyA7lOFNZ0T3pKaoc/qE1t4p/6/NoiB5/mlpTla1+Z7MBE8dsqsVfBEuPXHOHy1Jebqw18FB3QmgjfpqtFdcOIsv5dgw+bkhtleyYpwVv0lAEhzXJRfj6GnyjUXegwTM5udgb8vSce/8HISS9PIcCAAA=",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "329"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 17:36:15 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-03T17:36:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"charts\": [{\"row\": 0, \"width\": 6, \"chartId\": \"DZ4ALx6AYAA\", \"height\": 1, \"column\": 0}], \"selectedEventOverlays\": null, \"customProperties\": null, \"id\": \"DZ4AMNcAgAA\", \"discoveryOptions\": null, \"chartDensity\": \"DEFAULT\", \"filters\": {\"variables\": [{\"required\": true, \"alias\": \"app\", \"property\": \"app\", \"value\": [\"bar\"]}]}, \"description\": \"\", \"lastUpdatedBy\": null, \"creator\": \"ClusPSzAYAA\", \"locked\": false, \"maxDelayOverride\": null, \"eventOverlays\": null, \"created\": 1522776975236, \"tags\": null, \"lastUpdated\": 1522776975236, \"groupId\": \"DZ4AMM4AcAA\", \"name\": \"testy mctesterson\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "579"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.signalfx.com/v2/dashboard/DZ4AMNcAgAA"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSQVPCMBCF7/6KTs4eBKGotyo4wwwIM8hBGQ4hXdqMaVM3CVAZ/rtpWgoFPWXyvc3s5r3d33geYTFF3YdUcZ0T78kj/cFrMB+9k9taVQVfeHsLjmgYlrWfnWC084OPIHD1hSyFSdJCvatIDDyKdUFaFUG5PS/Y8lDHBfDt/eAty84IVINr0+q2272e/9jrtu/9kyjRzfAijJrOfuoZCDNKy2SKMgPUHNz0qRHCiSEohjzTXLoZSfkk5IrJDWA+cUrzCWwg1ROrCpo3lTUXGtCxyhwlDbJmS0s1T+ACbShyuhLQ8NZyKjh1jNAsqzz13EXkw/Vgx1UZx5oKBbV88atTH6tlCGtAhHBmoghU/b9FaXRV48zKrxsjZIIymKQiv26L8G04liFpNOeC0shZlV/z0YYKA+UAZEVthkunHNx5cL5GKE12tmLjcSdgx3j5GX9jQXTkgio9z8Lrpel2Hi4LnvO/V0dI9nUxM0norg82+mIDkIeNIElKy2SJtj/OvYQVp10Jm4PTFQgobBj8u0OaRjW4OfwCHB3oA5MDAAA=",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "425"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 17:36:15 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/DZ4AMNcAgAA"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_with_unexpected_data_type_failure.json
+++ b/tests/mocks/dashboard_create_with_filters_with_unexpected_data_type_failure.json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_update_with_filters_success.json
+++ b/tests/mocks/dashboard_update_with_filters_success.json
@@ -1,0 +1,283 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-04-03T19:40:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 19:40:27 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-03T19:40:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 19:40:27 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-03T19:40:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "[{\"name\": \"lol\", \"programText\": \"data(\\\"cpu.utilization\\\").publish()\", \"options\": {\"type\": \"TimeSeriesChart\"}}]"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "111"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWQwU7DMBBE73yF5TMHGpUWuBlaEBKoFdADIA7G3iYWThzZm5ZQ9d+xnZQkSD1FfrObnZndCSFUZNziDAqnsKbkitDZ/JatHl7o6Z/qAn8nOw8O6F42s29jeceWLGUszgfZ6CovgnrWkgxUmmEgo5ZYs+0PbJXELICJf+/JR3PZAkeIZ0bnSTK9GI+T6eVo0onGRg83unLL5x/22nqgonJo8qU1JVhUEN0XldZRlOCEVSUqEz3SZkUqJ8wGbL2IynAFNlDgwqua10NlrTSCjawtx5nKiuFJT1Hl8A9tuFX8U3ejIXr8aWpNVfb7fZRdNtXjTyUTB665w1UpjzfWG7iuByG0EV/N1pprB5Hl/HsGPm5IbZUcmKcFb9JQBIc1yUX4+hp8o1F3oMEzOT/aG/K0y73/Bc59456HAgAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "327"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 19:40:27 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-03T19:40:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"groupId\": \"DZ4dGMdAYAA\", \"lastUpdated\": 1522784427916, \"eventOverlays\": null, \"maxDelayOverride\": null, \"discoveryOptions\": null, \"description\": \"\", \"created\": 1522784427916, \"id\": \"DZ4dGRpAcAA\", \"tags\": null, \"charts\": [{\"chartId\": \"DZ4dGAPAgAA\", \"height\": 1, \"width\": 6, \"row\": 0, \"column\": 0}], \"locked\": false, \"creator\": \"ClusPSzAYAA\", \"filters\": {\"variables\": [{\"property\": \"app\", \"alias\": \"app\", \"required\": true, \"value\": [\"bar\"]}, {\"property\": \"env\", \"alias\": \"env\", \"required\": true, \"value\": [\"prod\"]}]}, \"lastUpdatedBy\": null, \"name\": \"testy mctesterson\", \"customProperties\": null, \"selectedEventOverlays\": null, \"chartDensity\": \"DEFAULT\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "653"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.signalfx.com/v2/dashboard/DZ4dGRpAcAA"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAMVTwU4CMRC9+xWbnj0IQVBvq6Ax0UBUDko81HZYGrvbOm0XVsK/2+2uCwt6NJ6avjfNm76Ztz6KIsIWFO0QMiNsQaKLiAxH1/H07okcN6wp8Vm09sA3dMur2pcev4kncRLHob6klXRpVrInNbIAkSxsiXRqBNVyt2ApuF2UQN/fN9FrpYxALQSZzmm3Ozjr9bqD805/SyoMPVxJZyaPn/Fz3QNhzliVTlBpQCsgdJ85KQPJwTAU2goVeiTVEy4MUzlgMQ5M+wnkkNmxZyUt2sxcSAsYsNocoxyytqRHrUhhD8opCvomoeWtx6kUNGCEal17GoWLLG7no5Uw1TjmVBpo6L1fbXU8pxHmgAj80SUJmOZ/s8rouiaYVRwKI2hJGYwzWRzKInw4gdWQLLpdwlgUrJ5f+1FOpYOqAfJG/QxfA7M5/skEyPL/MaEl/LcmeF3euBDOTdiuBJXTu0G759slFzv4g47ZNy6psVPND6JzdjLo7xdcFj8HSCr2vtc0SelqCD4AZQ5Q8NY6k4xW+02s/3IRpaw8fTD8IAJvQELpw+jXJFmaNMDR5gv2bLgSmQQAAA==",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "445"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 03 Apr 2018 19:40:28 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/DZ4dGRpAcAA"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/test_signal_analog_dashboards.py
+++ b/tests/test_signal_analog_dashboards.py
@@ -18,6 +18,7 @@ from signal_analog.errors import ResourceMatchNotFoundError, \
     ResourceHasMultipleExactMatchesError, ResourceAlreadyExistsError, \
     SignalAnalogError
 from signal_analog.flow import Data
+from signal_analog.filters import DashboardFilters, FilterVariable
 
 
 # Global config. This will store all recorded requests in the 'mocks' dir
@@ -370,6 +371,218 @@ def test_dashboard_delete_child_chart():
         resp_delete = dashboard.update()
         # We should only have one chart
         assert len(resp_delete['charts']) == 1
+
+
+def test_dashboard_create_with_filters_with_one_variable_success():
+    app_var = FilterVariable().with_alias('app') \
+        .with_property('app') \
+        .with_is_required(True) \
+        .with_value('bar')
+
+    dashboard_filter = DashboardFilters() \
+        .with_variables(app_var)
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_with_one_variable_success',
+                                      serialize_with='prettyjson'):
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .with_filters(dashboard_filter)\
+            .create()
+
+
+def test_dashboard_create_with_filters_with_multiple_variables_success():
+    app_var = FilterVariable().with_alias('app') \
+        .with_property('app') \
+        .with_is_required(True) \
+        .with_value('bar')
+
+    env_var = FilterVariable().with_alias('env') \
+        .with_property('env') \
+        .with_is_required(True) \
+        .with_value('prod')
+
+    dashboard_filter = DashboardFilters() \
+        .with_variables(app_var, env_var)
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_with_multiple_variables_success',
+                                      serialize_with='prettyjson'):
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .with_filters(dashboard_filter)\
+            .create()
+
+
+def test_dashboard_create_with_filters_with_multiple_values_success():
+    app_var = FilterVariable().with_alias('app') \
+        .with_property('app') \
+        .with_is_required(True) \
+        .with_value('bar1', 'bar2')
+
+    dashboard_filter = DashboardFilters() \
+        .with_variables(app_var)
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_with_multiple_values_success',
+                                      serialize_with='prettyjson'):
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .with_filters(dashboard_filter)\
+            .create()
+
+
+def test_dashboard_create_with_filters_with_empty_alias_failure():
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_with_empty_alias_failure',
+                                      serialize_with='prettyjson'):
+        with pytest.raises(ValueError):
+            app_var = FilterVariable().with_alias('') \
+                .with_property('app') \
+                .with_is_required(True) \
+                .with_value('bar')
+
+            dashboard_filter = DashboardFilters() \
+                .with_variables(app_var)
+
+            Dashboard(session=global_session)\
+                .with_name('testy mctesterson')\
+                .with_api_token('foo')\
+                .with_charts(mk_chart('lol'))\
+                .with_filters(dashboard_filter)\
+                .create()
+
+
+def test_dashboard_create_with_filters_with_empty_property_failure():
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_with_empty_property_failure',
+                                      serialize_with='prettyjson'):
+        with pytest.raises(ValueError):
+            app_var = FilterVariable().with_alias('app') \
+                .with_property('') \
+                .with_is_required(True) \
+                .with_value('bar')
+
+            dashboard_filter = DashboardFilters() \
+                .with_variables(app_var)
+
+            Dashboard(session=global_session)\
+                .with_name('testy mctesterson')\
+                .with_api_token('foo')\
+                .with_charts(mk_chart('lol'))\
+                .with_filters(dashboard_filter)\
+                .create()
+
+
+def test_dashboard_create_with_filters_with_missing_alias_failure():
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_with_missing_alias_failure',
+                                      serialize_with='prettyjson'):
+        with pytest.raises(ValueError):
+            app_var = FilterVariable().with_property('app') \
+                .with_is_required(True) \
+                .with_value('bar')
+
+            dashboard_filter = DashboardFilters() \
+                .with_variables(app_var)
+
+            Dashboard(session=global_session)\
+                .with_name('testy mctesterson')\
+                .with_api_token('foo')\
+                .with_charts(mk_chart('lol'))\
+                .with_filters(dashboard_filter)\
+                .create()
+
+
+def test_dashboard_create_with_filters_with_missing_property_failure():
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_with_missing_property_failure',
+                                      serialize_with='prettyjson'):
+        with pytest.raises(ValueError):
+            app_var = FilterVariable().with_alias('app') \
+                .with_is_required(True) \
+                .with_value('bar')
+
+            dashboard_filter = DashboardFilters() \
+                .with_variables(app_var)
+
+            Dashboard(session=global_session)\
+                .with_name('testy mctesterson')\
+                .with_api_token('foo')\
+                .with_charts(mk_chart('lol'))\
+                .with_filters(dashboard_filter)\
+                .create()
+
+
+def test_dashboard_create_with_filters_with_unexpected_data_type_failure():
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_with_unexpected_data_type_failure',
+                                      serialize_with='prettyjson'):
+        with pytest.raises(ValueError):
+            app_var = FilterVariable().with_alias('app') \
+                .with_is_required("THIS SHOULD BE BOOLEAN NOT A STRING") \
+                .with_value('bar')
+
+            dashboard_filter = DashboardFilters() \
+                .with_variables(app_var)
+
+            Dashboard(session=global_session)\
+                .with_name('testy mctesterson')\
+                .with_api_token('foo')\
+                .with_charts(mk_chart('lol'))\
+                .with_filters(dashboard_filter)\
+                .create()
+
+
+def test_dashboard_update_with_filters_success():
+    app_var = FilterVariable().with_alias('app') \
+        .with_property('app') \
+        .with_is_required(True) \
+        .with_value('bar')
+
+    env_var = FilterVariable().with_alias('env') \
+        .with_property('env') \
+        .with_is_required(True) \
+        .with_value('prod')
+
+    dashboard_filter = DashboardFilters() \
+        .with_variables(app_var, env_var)
+
+    with global_recorder.use_cassette('dashboard_update_with_filters_success',
+                                      serialize_with='prettyjson'):
+
+        # This Dashboard does not exist. So, a new dashboard should be created
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .with_filters(dashboard_filter)\
+            .update()
+
+
+def test_dashboard_update_existing_dashboard_with_filters_success():
+
+    app_var = FilterVariable().with_alias('app') \
+        .with_property('app') \
+        .with_is_required(True) \
+        .with_value('bar1', 'bar2')
+
+    dashboard_filter = DashboardFilters() \
+        .with_variables(app_var)
+
+    with global_recorder.use_cassette('dashboard_update_with_filters_success',
+                                      serialize_with='prettyjson'):
+
+        # This Dashboard already exists. So, it will be updated
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .with_filters(dashboard_filter)\
+            .update()
 
 
 def test_dashboard_read_success():


### PR DESCRIPTION
Introducing Dashboard Filters which can be configured to provide various filters that affect the behavior of all configured charts (overriding any conflicting filters at the chart level). You may wish to do this in order to quickly change the environment that you're observing for a given set of charts.
Here's an example how you create a dashboard with filters


```python
from signal_analog.flow import Data
from signal_analog.charts import TimeSeriesChart
from signal_analog.dashboards import Dashboard, DashboardGroup
from signal_analog.filters import DashboardFilters, FilterVariable

program = Data('cpu.utilization').publish()
chart = TimeSeriesChart().with_name('sample_chart').with_program(program)

dashboard = Dashboard().with_name('sample_dashboard').with_charts(chart)

app_var = FilterVariable().with_alias('app')\
    .with_property('app')\
    .with_is_required(True)\
    .with_value('foo')

env_var = FilterVariable().with_alias('env')\
    .with_property('env')\
    .with_is_required(True)\
    .with_value('prod')


app_filter = DashboardFilters() \
    .with_variables(app_var, env_var)


dashboard_response = dashboard.with_filters(app_filter).with_api_token(api_token).update()

print(dashboard_response)

```