### PR TITLE
Hypothesis timeout tests

### DIFF
--- a/tests/generators.py
+++ b/tests/generators.py
@@ -2,8 +2,12 @@
 
 from hypothesis.strategies import \
      text, characters, composite, recursive, sampled_from, floats
+from hypothesis import settings
 
 import signal_analog.flow as flow
+
+
+settings.load_profile("ci")
 
 
 def ascii():

--- a/tests/test_signal_analog.py
+++ b/tests/test_signal_analog.py
@@ -2,8 +2,14 @@
 # -*- coding: utf-8 -*-
 
 """Tests for `signal_analog` package."""
+import hypothesis
+from hypothesis import settings, HealthCheck
 
 from signal_analog import flow
+
+
+settings.register_profile("ci", deadline=9600, suppress_health_check=[HealthCheck.too_slow, HealthCheck.hung_test], timeout=hypothesis.unlimited)
+settings.load_profile("ci")
 
 
 def test_data_example():

--- a/tests/test_signal_analog_combinators.py
+++ b/tests/test_signal_analog_combinators.py
@@ -1,18 +1,20 @@
 """Tests for `signal_analog.combinators` package."""
 
-from hypothesis import given
+from hypothesis import given, settings, unlimited
 from hypothesis.strategies import one_of, just, none, lists
 import pytest
+import time
 
 import signal_analog.combinators as comb
 from .generators import ascii, flows
 
-
+@settings(timeout=unlimited)
 @given(one_of(none(), just("")))
 def test_binary_combinator_empty_operator(value):
     """Binary combinator should not allow empty operators"""
     with pytest.raises(ValueError):
         comb.NAryCombinator(value)
+        time.sleep(900) #to test the timeout setting.
 
 
 @given(op=ascii(), values=lists(elements=ascii()))

--- a/tests/test_signal_analog_combinators.py
+++ b/tests/test_signal_analog_combinators.py
@@ -5,7 +5,6 @@ import pytest
 
 import signal_analog.combinators as comb
 from .generators import ascii, flows
-import time
 
 
 settings.load_profile("ci")
@@ -20,7 +19,6 @@ def test_binary_combinator_empty_operator(value):
 
 @given(op=ascii(), values=lists(elements=ascii()))
 def test_binary_combinator_str(op, values):
-    time.sleep(9)
     """Binary combinator should always intersperse its op in the elements."""
     assert str(comb.NAryCombinator(op, *values)) == \
         " {0} ".format(op).join(map(str, values))

--- a/tests/test_signal_analog_combinators.py
+++ b/tests/test_signal_analog_combinators.py
@@ -1,24 +1,26 @@
 """Tests for `signal_analog.combinators` package."""
-
-from hypothesis import given, settings, unlimited
+from hypothesis import given, settings
 from hypothesis.strategies import one_of, just, none, lists
 import pytest
-import time
 
 import signal_analog.combinators as comb
 from .generators import ascii, flows
+import time
 
-@settings(timeout=unlimited)
+
+settings.load_profile("ci")
+
+
 @given(one_of(none(), just("")))
 def test_binary_combinator_empty_operator(value):
     """Binary combinator should not allow empty operators"""
     with pytest.raises(ValueError):
         comb.NAryCombinator(value)
-        time.sleep(900) #to test the timeout setting.
 
 
 @given(op=ascii(), values=lists(elements=ascii()))
 def test_binary_combinator_str(op, values):
+    time.sleep(9)
     """Binary combinator should always intersperse its op in the elements."""
     assert str(comb.NAryCombinator(op, *values)) == \
         " {0} ".format(op).join(map(str, values))


### PR DESCRIPTION
I added the hypothesis profile to test_signal_analog.py because it is loaded first. Then generators and combinators load that profile.

Would the profile be better created someplace else?

