### PR TITLE
Implementing Source and Time filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # History
 
+## 1.3.0(2018--4-17)
+
+  * Implementing the rest of the Dashboard Filters: `source` and `time`
+  
 ## 1.2.0 (2018-04-11)
   * Added an Assign function that will enable more complex detectors which are constructed by combining multiple data streams
   * Added a Ref flow operator that will enable referencing assignments in a way that can be validated at later steps by checking for an Assign object with a match between the reference string and the assignee

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ good overview of the SignalFx API consult the [upstream documentation][sfxdocs].
       - [Updating Dashboards](#updating-dashboards)
       - [Dashboard Filters](#providing-dashboard-filters)
       - [Creating Detectors](#creating-detectors)
+          - [Detectors That Combine Data Streams](#detectors-that-combine-data-streams)
           - [Building Detectors from Existing Charts](#building-detectors-from-existing-charts)
       - [Using Flow and Combinator Functions In Formulas](#using-flow-and-combinator-functions-in-formulas)
       - [Building Dashboard Groups](#building-dashboard-groups)
@@ -337,6 +338,46 @@ detector.with_api_token('foo').create()
 
 To add multiple alerting rules we would need to use different `detect`
 statements with distinct `label`s to differentiate them from one another.
+
+#### Detectors that Combine Data Streams
+
+More complex detectors, like those created as a function of two other data
+streams, require a more complex setup including data stream assignments.
+If we wanted to create a detector that watched for an average above a certain
+threshold, we may want to use the quotient of the sum() of the data and the
+count() of the datapoints over a given period of time.
+
+```python
+from signal_analog.flow import \
+    Assign, \
+    Data, \
+    Detect, \
+    Ref, \
+    When
+
+from signal_analog.combinators import \
+    Div, \
+    GT
+
+program = Program( \
+    Assign('my_var', Data('cpu.utilization')) \
+    Assign('my_other_var', Data('cpu.utilization').count()) \
+    Assign('mean', Div(Ref('my_var'), Ref('my_other_var'))) \
+    Detect(When(GT(Ref('mean'), 2000))) \
+)
+
+print(program)
+```
+
+The above code generates the following program:
+
+```
+my_var = data('cpu.utilization')
+my_other_var = data('cpu.utilization').count()
+mean = (my_var / my_other_var)
+
+when(detect(mean > 2000))
+```
 
 #### Building Detectors from Existing Charts
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Dashboards can be configured to provide various filters that affect the behavior
 
 
 ```python
-from signal_analog.filters import DashboardFilters, FilterVariable
+from signal_analog.filters import DashboardFilters, FilterVariable, FilterSource, FilterTime
 app_var = FilterVariable().with_alias('app')\
 .with_property('app')\
 .with_is_required(True)\
@@ -246,10 +246,18 @@ env_var = FilterVariable().with_alias('env')\
 .with_is_required(True)\
 .with_value('prod')
 
+aws_src = FilterSource().with_property("aws_region").with_value('us-west-2')
+
+time = FilterTime().with_start("-1h").with_end("Now")
+
 app_filter = DashboardFilters() \
-.with_variables(app_var, env_var)
+.with_variables(app_var, env_var) \ 
+.with_sources(aws_src) \
+.with_time(time)
 ```
-So, here we are creating a couple of filters "app=foo" and "env=prod".
+So, here we are creating a few filters "app=foo" and "env=prod", 
+a source filter "aws_region=us-west-2" and
+a time filter "-1h till Now"
 Now we can pass this config to a dashboard object:
 
 ```python

--- a/examples/dashboards.py
+++ b/examples/dashboards.py
@@ -46,7 +46,7 @@ Example 3: Update existing dashboard by removing one of the charts
 """
 
 dashboard_remove_chart = Dashboard()\
-    .with_name('Dashboard Name')\
+    .with_name('Dashboard With Multiple Charts')\
     .with_charts(chart, chart1)
 
 """
@@ -57,7 +57,7 @@ chart1 = TimeSeriesChart()\
     .with_name('Chart_Name_Renamed')\
     .with_program(program)
 dashboard_rename_chart = Dashboard()\
-    .with_name('Dashboard Name')\
+    .with_name('Dashboard With Multiple Charts')\
     .with_charts(chart, chart1)
 
 if __name__ == '__main__':

--- a/examples/filters.py
+++ b/examples/filters.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+"""Examples for the `signal_analog.filters` module."""
+
+from signal_analog.flow import Data, Filter
+from signal_analog.charts import TimeSeriesChart
+from signal_analog.dashboards import Dashboard
+from signal_analog.combinators import And
+from signal_analog.filters import DashboardFilters, FilterVariable, FilterSource, FilterTime
+
+"""
+Example 1: Creating a new Dashboard with Filter Variable
+
+This creates a new dashboard for the app specified and with the charts provided and with the Dashboard Filter provided
+"""
+filters = And(Filter('app', 'my-app'), Filter('env', 'test'))
+program = Data('cpu.utilization', filter=filters).publish()
+chart = TimeSeriesChart().with_name('Chart_Name').with_program(program)
+
+app_var = FilterVariable().with_alias('application name') \
+    .with_property('app') \
+    .with_is_required(True) \
+    .with_value('my-app')
+
+app_filter = DashboardFilters() \
+    .with_variables(app_var)
+
+dashboard_with_single_filter_variable = Dashboard()\
+    .with_name('Dashboard Name')\
+    .with_charts(chart)\
+    .with_filters(app_filter)
+
+
+"""
+Example 2: Creating a new Dashboard with multiple filters
+
+"""
+# With the same filters as above example,
+program = Data('cpu.utilization', filter=filters).publish()
+chart = TimeSeriesChart().with_name('Chart_Name').with_program(program)
+
+app_var = FilterVariable().with_alias('application name') \
+    .with_property('app') \
+    .with_is_required(True) \
+    .with_value('my-app1', 'my-app2')
+
+env_var = FilterVariable().with_alias('env')\
+    .with_property('env')\
+    .with_is_required(True)\
+    .with_value('prod')
+
+app_filter = DashboardFilters() \
+    .with_variables(app_var, env_var)
+
+dashboard_with_multiple_filter_variables = Dashboard()\
+    .with_name('Dashboard With Multiple Filters')\
+    .with_charts(chart)\
+    .with_filters(app_filter)
+
+
+"""
+Example 3: Creating a new Dashboard with source filter
+
+"""
+# With the same filters as above example,
+program = Data('cpu.utilization', filter=filters).publish()
+chart = TimeSeriesChart().with_name('Chart_Name').with_program(program)
+
+aws_src = FilterSource().with_property("aws_region").with_value('us-west-2')
+
+app_filter = DashboardFilters() \
+    .with_sources(aws_src)
+
+dashboard_with_source_filter = Dashboard()\
+    .with_name('Dashboard With Source Filter')\
+    .with_charts(chart)\
+    .with_filters(app_filter)
+
+
+"""
+Example 4: Creating a new Dashboard with time(as string) filter
+
+"""
+# With the same filters as above example,
+program = Data('cpu.utilization', filter=filters).publish()
+chart = TimeSeriesChart().with_name('Chart_Name').with_program(program)
+
+time = FilterTime().with_start("-1h").with_end("Now")
+
+app_filter = DashboardFilters() \
+    .with_time(time)
+
+dashboard_with_time_as_string_filter = Dashboard()\
+    .with_name('Dashboard With Time as String Filter')\
+    .with_charts(chart)\
+    .with_filters(app_filter)
+
+
+"""
+Example 5: Creating a new Dashboard with time(as integer) filter
+
+"""
+# With the same filters as above example,
+program = Data('cpu.utilization', filter=filters).publish()
+chart = TimeSeriesChart().with_name('Chart_Name').with_program(program)
+
+time = FilterTime().with_start(1523808000000).with_end(1523894400000)
+
+app_filter = DashboardFilters() \
+    .with_time(time)
+
+dashboard_with_time_as_integer_filter = Dashboard()\
+    .with_name('Dashboard With Time as Integer Filter')\
+    .with_charts(chart)\
+    .with_filters(app_filter)
+
+
+"""
+Example 6: Update an existing Dashboard by removing one of the filters
+
+"""
+
+app_filter = DashboardFilters().with_variables(app_var)
+
+dashboard_remove_filter = Dashboard()\
+    .with_name('Dashboard With Multiple Filters')\
+    .with_charts(chart)\
+    .with_filters(app_filter)
+
+
+if __name__ == '__main__':
+    from signal_analog.cli import CliBuilder
+    cli = CliBuilder().with_resources(dashboard_with_single_filter_variable,
+                                      dashboard_with_multiple_filter_variables,
+                                      dashboard_with_source_filter,
+                                      dashboard_with_time_as_string_filter,
+                                      dashboard_with_time_as_integer_filter,
+                                      dashboard_remove_filter)\
+        .build()
+    cli()

--- a/signal_analog/charts.py
+++ b/signal_analog/charts.py
@@ -25,7 +25,7 @@ class Chart(Resource):
 
         Useful when updating/deleting charts.
         """
-        util.is_valid(id)
+        util.assert_valid(id)
         self.options.update({'id': id})
         return self
 
@@ -37,7 +37,7 @@ class Chart(Resource):
 
         https://developers.signalfx.com/docs/signalflow-overview
         """
-        util.is_valid(program)
+        util.assert_valid(program)
         self.options.update({'programText': program})
         return self
 
@@ -228,7 +228,7 @@ class PublishLabelOptions(ChartOption):
             display_name: an alternate name to show in the legend
         """
         for arg in [label, display_name]:
-            util.is_valid(arg)
+            util.assert_valid(arg)
         util.in_given_enum(palette_index, PaletteColor)
         util.in_given_enum(plot_type, PlotType)
         if y_axis not in [0, 1]:
@@ -254,21 +254,21 @@ class DisplayOptionsMixin(object):
 
     def with_color_by(self, color_by):
         """Determine how timeseries are colored in this chart."""
-        util.is_valid(color_by)
+        util.assert_valid(color_by)
         util.in_given_enum(color_by, ColorBy)
         self.chart_options.update({'colorBy': color_by.value})
         return self
 
     def with_sort_by(self, sort_by):
         """Determine how values are sorted."""
-        util.is_valid(sort_by)
+        util.assert_valid(sort_by)
         util.in_given_enum(sort_by, SortBy)
         self.chart_options.update({'sortBy': sort_by.value})
         return self
 
     def with_unit_prefix(self, prefix):
         """Add a unit prefix to this chart."""
-        util.is_valid(prefix)
+        util.assert_valid(prefix)
         util.in_given_enum(prefix, UnitPrefix)
         self.chart_options.update({'unitPrefix': prefix.value})
         return self
@@ -293,8 +293,8 @@ class DisplayOptionsMixin(object):
             This TimeSeriesChart with program options.
         """
 
-        util.is_valid(min_resolution)
-        util.is_valid(max_delay)
+        util.assert_valid(min_resolution)
+        util.assert_valid(max_delay)
         program_opts = {
             'minimumResolution': min_resolution,
             'maxDelay': max_delay,
@@ -305,7 +305,7 @@ class DisplayOptionsMixin(object):
 
     def with_publish_label_options(self, *publish_opts):
         """Plot-level customization, associated with a publish statement."""
-        util.is_valid(publish_opts)
+        util.assert_valid(publish_opts)
         opt = list(map(lambda o: o.to_dict(), publish_opts))
         self.chart_options.update({'publishLabelOptions': opt})
         return self
@@ -327,7 +327,7 @@ class TimeSeriesChart(Chart, DisplayOptionsMixin):
         Returns:
             This TimeSeriesChart with absolute time config
         """
-        util.is_valid(range)
+        util.assert_valid(range)
         opts = {'type': 'relative', 'range': range}
         self.chart_options.update({'time': opts})
         return self
@@ -342,8 +342,8 @@ class TimeSeriesChart(Chart, DisplayOptionsMixin):
         Returns:
             This TimeSeriesChart with a relative time config.
         """
-        util.is_valid(start)
-        util.is_valid(end)
+        util.assert_valid(start)
+        util.assert_valid(end)
         opts = {'type': 'absolute', 'start': start, 'end': end}
         self.chart_options.update({'time': opts})
         return self
@@ -354,7 +354,7 @@ class TimeSeriesChart(Chart, DisplayOptionsMixin):
         Don't leave your axes laying about or this guy might show up:
         https://youtu.be/V2FygG84bg8
         """
-        util.is_valid(axes)
+        util.assert_valid(axes)
         self.chart_options.update({
             'axes': list(map(lambda x: x.to_dict(), axes))
         })
@@ -362,7 +362,7 @@ class TimeSeriesChart(Chart, DisplayOptionsMixin):
 
     def with_legend_options(self, field_opts):
         """Options for the behavior of this chart's legend."""
-        util.is_valid(field_opts)
+        util.assert_valid(field_opts)
         opts = {'fields': list(map(lambda x: x.to_dict(), field_opts))}
         self.chart_options.update({'legendOptions': opts})
         return self
@@ -415,20 +415,20 @@ class TimeSeriesChart(Chart, DisplayOptionsMixin):
 
     def with_default_plot_type(self, plot_type):
         """The default plot display style for the visualization."""
-        util.is_valid(plot_type)
+        util.assert_valid(plot_type)
         util.in_given_enum(plot_type, PlotType)
         self.chart_options.update({'defaultPlotType': plot_type.value})
         return self
 
     def with_axis_precision(self, num):
         """Force a specific number of significant digits in the y-axis."""
-        util.is_valid(num)
+        util.assert_valid(num)
         self.chart_options.update({'axisPrecision': num})
         return self
 
     def with_chart_legend_options(self, dimension, show_legend=False):
         """Show the on-chart legend using the given dimension."""
-        util.is_valid(dimension)
+        util.assert_valid(dimension)
         opts = {
             'showLegend': show_legend,
             'dimensionInLegend': dimension
@@ -445,13 +445,13 @@ class SingleValueChart(Chart, DisplayOptionsMixin):
 
     def with_refresh_interval(self, interval):
         """How often (in milliseconds) to refresh the values of the list."""
-        util.is_valid(interval)
+        util.assert_valid(interval)
         self.chart_options.update({'refreshInterval': interval})
         return self
 
     def with_maximum_precision(self, precision):
         """The maximum precision to for values displayed in the list."""
-        util.is_valid(precision)
+        util.assert_valid(precision)
         self.chart_options.update({'maximumPrecision': precision})
         return self
 
@@ -474,7 +474,7 @@ class SingleValueChart(Chart, DisplayOptionsMixin):
                       the highest specified value. If true, values are red if
                       they are below the lowest specified value.
         """
-        util.is_valid(thresholds)
+        util.assert_valid(thresholds)
         thresholds.sort(reverse=True)
         opts = {'thresholds': thresholds, 'inverted': inverted}
         self.chart_options.update({'colorScale': opts})
@@ -489,13 +489,13 @@ class ListChart(Chart, DisplayOptionsMixin):
 
     def with_refresh_interval(self, interval):
         """How often (in milliseconds) to refresh the values of the list."""
-        util.is_valid(interval)
+        util.assert_valid(interval)
         self.chart_options.update({'refreshInterval': interval})
         return self
 
     def with_maximum_precision(self, precision):
         """The maximum precision to for values displayed in the list."""
-        util.is_valid(precision)
+        util.assert_valid(precision)
         self.chart_options.update({'maximumPrecision': precision})
         return self
 
@@ -512,7 +512,7 @@ class HeatmapChart(Chart, DisplayOptionsMixin):
         Arguments:
             thresholds: The thresholds to set for the color range being used.
         """
-        util.is_valid(thresholds)
+        util.assert_valid(thresholds)
         thresholds.sort(reverse=True)
         opts = {'thresholds': thresholds}
         self.chart_options.update({'colorScale': opts})

--- a/signal_analog/detectors.py
+++ b/signal_analog/detectors.py
@@ -52,7 +52,7 @@ class PagerDutyNotification(Notification):
         Arguments:
             pd_id: the id of the PagerDuty integration to include.
         """
-        util.is_valid(pd_id)
+        util.assert_valid(pd_id)
         self.options = {'type': 'PagerDuty', 'credentialId': pd_id}
 
 
@@ -73,8 +73,8 @@ class SlackNotification(Notification):
             slack_id: the slack integration id to use
             channel_name: the name of the channel to send alerts to
         """
-        util.is_valid(slack_id)
-        util.is_valid(channel_name)
+        util.assert_valid(slack_id)
+        util.assert_valid(channel_name)
 
         self.options = {
             'type': 'Slack',
@@ -101,8 +101,8 @@ class HipChatNotification(Notification):
             room_name: the HipChat room name to post integrations to
         """
 
-        util.is_valid(hp_id)
-        util.is_valid(room_name)
+        util.assert_valid(hp_id)
+        util.assert_valid(room_name)
 
         self.options = {
             'type': 'HipChat',
@@ -124,7 +124,7 @@ class ServiceNowNotification(Notification):
         Arguments:
             sn_id: the ServiceNow integration id to use
         """
-        util.is_valid(sn_id)
+        util.assert_valid(sn_id)
 
         self.options = {
             'type': 'ServiceNow',
@@ -146,8 +146,8 @@ class VictorOpsNotification(Notification):
             vo_id: the VictorOps integration id to use
             routing_key: a VictorOps routing key
         """
-        util.is_valid(vo_id)
-        util.is_valid(routing_key)
+        util.assert_valid(vo_id)
+        util.assert_valid(routing_key)
 
         self.options = {
             'type': 'VictorOps',
@@ -169,7 +169,7 @@ class WebhookNotification(Notification):
                     HMAC-SHA1 digest of the request body using the shared
                     secret.
         """
-        util.is_valid(url)
+        util.assert_valid(url)
 
         self.options = {
             'type': 'Webhook',
@@ -191,7 +191,7 @@ class TeamNotification(Notification):
         Arguments:
             team_id: the id of the team to message.
         """
-        util.is_valid(team_id)
+        util.assert_valid(team_id)
 
         self.options = {
             'type': 'Team',
@@ -210,7 +210,7 @@ class TeamEmailNotification(Notification):
         Arguments:
             team_id: the id of the team to e-mail.
         """
-        util.is_valid(team_id)
+        util.assert_valid(team_id)
 
         self.options = {
             'type': 'TeamEmail',
@@ -237,13 +237,13 @@ class Rule(object):
 
     def for_label(self, label):
         """A label matching a `detect` label within the program text."""
-        util.is_valid(label)
+        util.assert_valid(label)
         self.options.update({'detectLabel': label})
         return self
 
     def with_description(self, description):
         """Human-readable description for this rule."""
-        util.is_valid(description)
+        util.assert_valid(description)
         self.options.update({'description': description})
         return self
 
@@ -280,7 +280,7 @@ class Rule(object):
            Available variables can be found here:
            https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#message-variables
         """
-        util.is_valid(body)
+        util.assert_valid(body)
         self.options.update({'parameterizedBody': body})
         return self
 
@@ -290,7 +290,7 @@ class Rule(object):
 
         See the documentation for `with_parameterized_body` for more detail.
         """
-        util.is_valid(subject)
+        util.assert_valid(subject)
         self.options.update({'parameterizedSubject': subject})
         return self
 
@@ -300,7 +300,7 @@ class Rule(object):
         This can be used with custom notification messages. It can be
         referenced using the {{runbookUrl}} template var.
         """
-        util.is_valid(url)
+        util.assert_valid(url)
         self.options.update({'runbookUrl': url})
         return self
 
@@ -311,7 +311,7 @@ class Rule(object):
         This can be used with custom notification messages. It can be
         referenced using the {{tip}} template var.
         """
-        util.is_valid(tip)
+        util.assert_valid(tip)
         self.options.update({'tip': tip})
         return self
 
@@ -334,7 +334,7 @@ class TimeConfig(object):
         return self
 
     def __add_millis__(self, millis, key):
-        util.is_valid(millis)
+        util.assert_valid(millis)
         self.options.update({key: millis})
         return self
 
@@ -430,7 +430,7 @@ class Detector(Resource):
 
     def with_max_delay(self, delay):
         """Used to handle late datapoints."""
-        util.is_valid(delay)
+        util.assert_valid(delay)
         self.options.update({'maxDelay': delay})
         return self
 

--- a/signal_analog/filters.py
+++ b/signal_analog/filters.py
@@ -185,7 +185,6 @@ class DashboardFilters(object):
                 st = time.options['start']
                 et = time.options['end']
                 st_type = type(st)
-                et_type = type(et)
 
                 # We have to validate bool separately as it is a subclass of int
                 if not isinstance(st, (str, int)) or isinstance(st, bool):
@@ -197,8 +196,8 @@ class DashboardFilters(object):
                     elif st[-1:] not in ['m', 'h', 'd', 'w']:
                         raise ValueError(
                             "Start time value must end with a units indicator. Allowed units indicators are "
-                            "m, h, d, w representing minutes, hours, days, and weeks respectively. Instead, "
-                            "got '{0}'".format(st[-1:]))
+                            "m, h, d, w(case-sensitive) representing minutes, hours, days, and weeks respectively. "
+                            "Instead, got '{0}'".format(st[-1:]))
                     else:
                         try:
                             val = int(st[1:-1])
@@ -208,8 +207,9 @@ class DashboardFilters(object):
                         except ValueError:
                             raise ValueError("A positive integer must follow the negative sign for Start time. "
                                              "Instead, got '{0}'".format(st[1:-1]))
-                    if et.title() != "Now":
-                        raise ValueError('End time value should be "Now" when Start time is defined as a string')
+                    if et != "Now":
+                        raise ValueError('End time value should be "Now"(case-sensitive) when Start time '
+                                         'is defined as a string. Instead, got "{0}"'.format(et))
                 elif isinstance(st, int):
                     if st < 0 and et < 0:
                         raise ValueError("Start time and End time cannot be Negative values")

--- a/signal_analog/filters.py
+++ b/signal_analog/filters.py
@@ -12,12 +12,12 @@ class FilterVariable(object):
         self.options = {}
 
     def with_alias(self, alias):
-        util.is_valid(alias, error_message='"alias" cannot be empty', expected_type=str)
+        util.assert_valid(alias, error_message='"alias" cannot be empty', expected_type=str)
         self.options.update({'alias': alias})
         return self
 
     def with_apply_if_exists(self, apply_if_exists):
-        util.is_valid(apply_if_exists, expected_type=bool)
+        util.assert_valid(apply_if_exists, expected_type=bool)
         self.options.update({'apply_if_exists': apply_if_exists})
         return self
 
@@ -32,22 +32,22 @@ class FilterVariable(object):
         return self
 
     def with_property(self, property):
-        util.is_valid(property, error_message='"property" cannot be empty', expected_type=str)
+        util.assert_valid(property, error_message='"property" cannot be empty', expected_type=str)
         self.options.update({'property': property})
         return self
 
     def with_replace_only(self, replace_only):
-        util.is_valid(replace_only, expected_type=bool)
+        util.assert_valid(replace_only, expected_type=bool)
         self.options.update({'replaceOnly': replace_only})
         return self
 
     def with_is_required(self, required):
-        util.is_valid(required, expected_type=bool)
+        util.assert_valid(required, expected_type=bool)
         self.options.update({'required': required})
         return self
 
     def with_is_restricted(self, restricted):
-        util.is_valid(restricted, expected_type=bool)
+        util.assert_valid(restricted, expected_type=bool)
         self.options.update({'restricted': restricted})
         return self
 
@@ -71,19 +71,19 @@ class FilterSource(object):
         self.options = {}
 
     def with_property(self, property):
-        util.is_valid(property, error_message='"property" cannot be empty', expected_type=str)
+        util.assert_valid(property, error_message='"property" cannot be empty', expected_type=str)
         self.options.update({'property': property})
         return self
 
     def with_value(self, *values):
-        util.is_valid(*values, error_message='"value" cannot be empty')
+        util.assert_valid(*values, error_message='"value" cannot be empty')
         self.options.update({'value': []})
         for value in values:
             self.options['value'].append(value)
         return self
 
     def with_is_not(self, is_not):
-        util.is_valid(is_not, expected_type=bool, error_message='"NOT" cannot be empty. It should be a boolean')
+        util.assert_valid(is_not, expected_type=bool, error_message='"NOT" cannot be empty. It should be a boolean')
         self.options.update({'NOT': is_not})
         return self
 
@@ -97,12 +97,12 @@ class FilterTime(object):
         self.options = {}
 
     def with_start(self, start):
-        util.is_valid(start, error_message='"start" cannot be empty')
+        util.assert_valid(start, error_message='"start" cannot be empty')
         self.options.update({'start': start})
         return self
 
     def with_end(self, end):
-        util.is_valid(end, error_message='"end" cannot be empty')
+        util.assert_valid(end, error_message='"end" cannot be empty')
         self.options.update({'end': end})
         return self
 

--- a/signal_analog/filters.py
+++ b/signal_analog/filters.py
@@ -58,6 +58,54 @@ class FilterVariable(object):
         return self
 
 
+class FilterSource(object):
+    """
+    Each element represents an adhoc filter to apply to the charts within the dashboard. Each filter can key off of one
+    dimension or custom property (either user defined or supplied by default) and can either include or exclude all data
+    matching the supplied criteria. The properties of the included objects are indicated as
+    filters.sources[x].propertyName; this notation means the propertyName property is part of the object in each element
+    of the sources array.
+    """
+
+    def __init__(self):
+        self.options = {}
+
+    def with_property(self, property):
+        util.is_valid(property, error_message='"property" cannot be empty', expected_type=str)
+        self.options.update({'property': property})
+        return self
+
+    def with_value(self, *values):
+        self.options.update({'value': []})
+        for value in values:
+            self.options['value'].append(value)
+        return self
+
+    def with_is_not(self, is_not):
+        util.is_valid(is_not, expected_type=bool, error_message='"NOT" cannot be empty. It should be a boolean')
+        self.options.update({'NOT': is_not})
+        return self
+
+
+class FilterTime(object):
+    """
+    The properties of the included objects are indicated as filters.time.propertyName.
+    """
+
+    def __init__(self):
+        self.options = {}
+
+    def with_start(self, start):
+        util.is_valid(start, error_message='"start" cannot be empty')
+        self.options.update({'start': start})
+        return self
+
+    def with_end(self, end):
+        util.is_valid(end, error_message='"end" cannot be empty')
+        self.options.update({'end': end})
+        return self
+
+
 class DashboardFilters(object):
     """
     A filters model to be attached to a dashboard. Filters allow fine grained control over the data displayed
@@ -80,4 +128,96 @@ class DashboardFilters(object):
             elif 'property' not in variable.options:
                 raise ValueError('"property" is a required parameter')
             self.options['variables'].append(variable.options)
+        return self
+
+    def with_sources(self, *sources):
+        self.options.update({'sources': []})
+        for source in sources:
+            if 'value' not in source.options and 'property' not in source.options:
+                raise ValueError('"property" and "value" are required parameters')
+            elif 'property' not in source.options:
+                raise ValueError('"property" is a required parameter')
+            elif 'value' not in source.options:
+                raise ValueError('"value" is a required parameter')
+            self.options['sources'].append(source.options)
+        return self
+
+    def with_time(self, time):
+        # Checking if either start or end time is defined
+        if bool(time.options):
+            """
+            All the code below evaluates the following conditions and throws an error if any of them are not met
+
+            filters.time.start-->	Type: 
+                                        string or integer	
+                                    Must be an integer if filters.time.end is an integer
+                                    Must be a string if filters.time.end is a string
+                                    If integer:
+                                        Minimum value = 0
+                                        Value must be smaller than value of filters.time.end
+                                    If string:
+                                        Value must start with a negative sign
+                                        A positive integer must follow the negative sign
+                                        Value must end with a units indicator. Allowed units indicators are m, h, d, w 
+                                        representing minutes, hours, days, and weeks respectively
+
+            filters.time.end-->	    Type:
+                                        enumerated string or integer	
+                                    Must be an integer if filters.time.start is an integer
+                                    Must be a string if filters.time.start is a string
+                                    If integer:
+                                        Minimum value = 0
+                                        Value must be larger than value of filters.time.start
+                                    If string:
+                                        Allowed value is "Now"
+
+            """
+            if 'start' in time.options and 'end' not in time.options:
+                raise ValueError("End time should be provided")
+            elif 'end' in time.options and 'start' not in time.options:
+                raise ValueError("Start time should be provided")
+            elif not isinstance(time.options['start'], type(time.options['end'])):
+                raise ValueError("Start and End times should be of the same data type."
+                                 "Instead, got Start time as {0} and End time as {1}"
+                                 .format(type(time.options['start']), type(time.options['end'])))
+            else:
+                st = time.options['start']
+                et = time.options['end']
+                st_type = type(st)
+                et_type = type(et)
+
+                # We have to validate bool separately as it is a subclass of int
+                if not isinstance(st, (str, int)) or isinstance(st, bool):
+                    raise ValueError("Start and End times must be either a String or an Integer. "
+                                     "Instead, got a {0}".format(st_type))
+                elif isinstance(st, str):
+                    if st[:1] is not "-":
+                        raise ValueError("Start time value must start with a negative sign")
+                    elif st[-1:] not in ['m', 'h', 'd', 'w']:
+                        raise ValueError(
+                            "Start time value must end with a units indicator. Allowed units indicators are "
+                            "m, h, d, w representing minutes, hours, days, and weeks respectively. Instead, "
+                            "got '{0}'".format(st[-1:]))
+                    else:
+                        try:
+                            val = int(st[1:-1])
+                            if val < 0:
+                                raise ValueError("A positive integer must follow the negative sign for Start time. "
+                                                 "Instead, got '{0}'".format(st[1:-1]))
+                        except ValueError:
+                            raise ValueError("A positive integer must follow the negative sign for Start time. "
+                                             "Instead, got '{0}'".format(st[1:-1]))
+                    if et.title() != "Now":
+                        raise ValueError('End time value should be "Now" when Start time is defined as a string')
+                elif isinstance(st, int):
+                    if st < 0 and et < 0:
+                        raise ValueError("Start time and End time cannot be Negative values")
+                    elif st < 0:
+                        raise ValueError("Start time cannot be a Negative value")
+                    elif et < 0:
+                        raise ValueError("End time cannot be a Negative value")
+                    elif st > et:
+                        raise ValueError("Start time should be smaller than End time")
+
+            self.options.update({'time': time.options})
         return self

--- a/signal_analog/filters.py
+++ b/signal_analog/filters.py
@@ -76,6 +76,7 @@ class FilterSource(object):
         return self
 
     def with_value(self, *values):
+        util.is_valid(*values, error_message='"value" cannot be empty')
         self.options.update({'value': []})
         for value in values:
             self.options['value'].append(value)
@@ -220,4 +221,7 @@ class DashboardFilters(object):
                         raise ValueError("Start time should be smaller than End time")
 
             self.options.update({'time': time.options})
-        return self
+            return self
+        else:
+            raise ValueError("Start and End time are required")
+

--- a/signal_analog/flow.py
+++ b/signal_analog/flow.py
@@ -525,10 +525,10 @@ class Assign(Function):
         """
 
         # Ensure that assignee is valid and is a string
-        util.is_valid(assignee, str)
+        util.assert_valid(assignee, str)
 
         # Ensure that expr is valid
-        util.is_valid(expr)
+        util.assert_valid(expr)
 
         self.assignee = assignee
         self.expr = expr

--- a/signal_analog/resources.py
+++ b/signal_analog/resources.py
@@ -55,13 +55,13 @@ class Resource(object):
 
     def with_name(self, name):
         """The name to give this resource."""
-        util.is_valid(name)
+        util.assert_valid(name)
         self.options.update({'name': name})
         return self
 
     def with_description(self, description):
         """The description to attach to this resource."""
-        util.is_valid(description)
+        util.assert_valid(description)
         self.options.update({'description': description})
         return self
 
@@ -70,7 +70,7 @@ class Resource(object):
 
         Useful for creates/deletes.
         """
-        util.is_valid(ident)
+        util.assert_valid(ident)
         self.options.update({'id': ident})
         return self
 
@@ -81,17 +81,17 @@ class Resource(object):
         Either pass one in at Resource instantiation time or provide one
         via the `with_api_token` method."""
 
-        util.is_valid(token, message)
+        util.assert_valid(token, message)
         self.api_token = token
 
     def __set_endpoint__(self, endpoint):
         """Internal helper for setting valid endpoints."""
-        util.is_valid(endpoint,  error_message="Cannot proceed with an empty endpoint")
+        util.assert_valid(endpoint, error_message="Cannot proceed with an empty endpoint")
         self.endpoint = endpoint
 
     def __set_base_url__(self, base_url):
         """Internal helper for setting valid base_urls."""
-        util.is_valid(base_url, error_message="Cannot proceed with empty base_url")
+        util.assert_valid(base_url, error_message="Cannot proceed with empty base_url")
         self.base_url = base_url
 
     def with_api_token(self, token):
@@ -127,7 +127,7 @@ class Resource(object):
                 opts.update({'charts': util.flatten_charts(self.options)})
             return opts
 
-        util.is_valid(self.api_token)
+        util.assert_valid(self.api_token)
 
         response = self.session_handler.request(
             action,

--- a/signal_analog/util.py
+++ b/signal_analog/util.py
@@ -34,7 +34,7 @@ def is_valid(value, error_message=None, expected_type=None):
     Returns:
         Nothing.
     """
-    if not value:
+    if value is '' or value is None:
         if error_message:
             raise ValueError(error_message)
         else:

--- a/signal_analog/util.py
+++ b/signal_analog/util.py
@@ -23,7 +23,7 @@ def in_given_enum(value, enum):
         raise ValueError(msg.format(value, valid_values))
 
 
-def is_valid(value, error_message=None, expected_type=None):
+def assert_valid(value, error_message=None, expected_type=None):
     """Void method ensuring value is non-empty.
 
     Arguments:

--- a/tests/mocks/dashboard_create_with_filters_source_NOT_success.json
+++ b/tests/mocks/dashboard_create_with_filters_source_NOT_success.json
@@ -1,0 +1,215 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-04-16T21:45:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 21:45:57 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-16T21:45:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "[{\"name\": \"lol\", \"programText\": \"data(\\\"cpu.utilization\\\").publish()\", \"options\": {\"type\": \"TimeSeriesChart\"}}]"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "111"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSUUvDMBSF3/0VJc8+2Gkd+lbdBEHYYA5R8SEmd200bUpys9mN/XeTNNp1sKfS79zbnHPS3VmSEGqxVFpsgb9ogaANSW6TnVOchkCr8P6efJx3yJo44pAje48JK6nGCdRGYOs1Mpk+5MunZ9KrcSd+OKBH3s3S8ehtATnLcxIPYUraqvbqRSQliKJET9JItNocDmwEx9KDa++qs0uYBooQjkmz0eVNmqXZeHyV9aLSwcO9tGa+2Oav0QNh1qCq5lo1oFFAcF9bKYPIwTAtGhQqeCTdCheGqTXodhaU4QqsocaZUyVth8pKyKPWjbKaDY/0dyEqOEJrqgX9lP3o/4UUWtlm0K/Ii79s4pB/9ZklNbhs+OnGDgbu2kEIqdh3t7Wi0kBgFf2ZgIvrU2vBB+ZJTbs07hcz2CYV809Xg2s06AYkOManJ3tDWvS597/88rArywIAAA==",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "352"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 21:45:57 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-16T21:45:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"authorizedWriters\": {\"teams\": [], \"users\": []}, \"chartDensity\": \"DEFAULT\", \"charts\": [{\"chartId\": \"Da72ZSeAcAA\", \"column\": 0, \"height\": 1, \"row\": 0, \"width\": 6}], \"created\": 1523915157745, \"creator\": \"ClusPSzAYAA\", \"customProperties\": null, \"description\": \"\", \"discoveryOptions\": null, \"eventOverlays\": null, \"filters\": {\"sources\": [{\"property\": \"aws_region\", \"value\": [\"us-west-2\"], \"NOT\": true}]}, \"groupId\": \"Da72ZSiAgAA\", \"id\": \"Da72ZSjAYAA\", \"lastUpdated\": 1523915157745, \"lastUpdatedBy\": null, \"locked\": false, \"maxDelayOverride\": null, \"name\": \"testy mctesterson\", \"selectedEventOverlays\": null, \"tags\": null}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "618"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.signalfx.com/v2/dashboard/Da72ZSjAYAA"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSQU/DMAyF7/yKKmeQtsEYcCtsSEiITYIJAUIopF4bSJvKcTbKxH8naTpKNzhV/Z5du+95vRdFjFvKNMpPSO5REqBh0Vm0dorTCHhevxdWqf3ArGlqPHPoy3MmMo40hsJIqrzIxpPLeH59x1q1bnrafLpGV0mo5aPB4y3EIo5ZM0VoZfPCq72GZCDTjDzpNwT16nfBSiaUeXDst4qew2QETlCP6Q8Hh6f9YX84Gh0NW1FjvcOFsmZ2+xk/NDswYQ3pfIa6BCQJHRtYAkagLEnqekcWWhJphF4CVtNa6bbAEgqaOlXxqqsspNry3WiLAjqGOXozvfOE0ML+hvGyVNXVYvIhTTB4wZVp5TKsHyLhK/OCkPqdfwqWXFkIc1yyByswdDBg0XOtNyb6Q5A5bN3BkqPkrwp2byFFbctOtDJON7bK3/yttVtxQ/My2QnrpDfobRecV39HprR4D+0/LrCcf4zBWe6dR5l0/oIVPPyWO3RDVZQL/3RRNA4xAwocSyb/Zkc8bQ34+gZppavJUQMAAA==",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "412"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 21:45:57 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/Da72ZSjAYAA"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_source_success.json
+++ b/tests/mocks/dashboard_create_with_filters_source_success.json
@@ -1,0 +1,215 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-04-16T22:01:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 22:01:44 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-16T22:01:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "[{\"name\": \"lol\", \"programText\": \"data(\\\"cpu.utilization\\\").publish()\", \"options\": {\"type\": \"TimeSeriesChart\"}}]"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "111"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSUU/CMBSF3/0VS599YCIovk3BxMQEEkFjiA+1vWyN3brctuAg/HfbbriNhKdl37l3Ped0h6soItSaTKHYA/9AYQA1iR6ig1OcZoDm4X0dfV3XyOpmxCFHjh4TllE0Uyi0MJXXyHT2nKxel6RVm53mwwG98HqW3o3y5T75TBLSHMKUtHnh1UFDMhBpZjyJG4Jq1x3YCW4yD8beVW2XMARqIBwTj26Gk3gcD24nw/tWVBg8PEmrF2+tB8KsNipfoCoBjYDgvrBSBpGDZihKI1TwSOoVLjRTW8BqHpT+CmyhMHOnSlr1lY2QZ61rZZH1j/R3IXI4Q1uKgn7LdvT/QlJUtuz2+z5P2Cmb6PJFkp64pNqsSn65sc7AY9ULIRX7qbc2VGoILKe/U3BxfWoUvGeeFLRO434xbaooZ/7panCNBl2DBMf47GJvhqZt7uMflxmK78sCAAA=",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "353"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 22:01:44 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-16T22:01:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"authorizedWriters\": {\"teams\": [], \"users\": []}, \"chartDensity\": \"DEFAULT\", \"charts\": [{\"chartId\": \"Da75mTzAYAA\", \"column\": 0, \"height\": 1, \"row\": 0, \"width\": 6}], \"created\": 1523916104938, \"creator\": \"ClusPSzAYAA\", \"customProperties\": null, \"description\": \"\", \"discoveryOptions\": null, \"eventOverlays\": null, \"filters\": {\"sources\": [{\"property\": \"aws_region\", \"value\": [\"us-west-2\"]}]}, \"groupId\": \"Da75mVOAcAA\", \"id\": \"Da75mVPAgAA\", \"lastUpdated\": 1523916104938, \"lastUpdatedBy\": null, \"locked\": false, \"maxDelayOverride\": null, \"name\": \"testy mctesterson\", \"selectedEventOverlays\": null, \"tags\": null}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "605"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.signalfx.com/v2/dashboard/Da75mVPAgAA"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSW0/CQBCF3/0VzT5Dwl3xrQomJMaSCBpjiFm3Q7tx2232AhTCf3e321IK+tT0OzOd6TlzuPE8hLWKuaB7CN8FVSAk8u69g1GMpgAnxXuqGWs5pmVZY5lBR8sRibFQE0glVbkV0WT65C+fF6hWi6bP6tMFmoWuFt8Ok8Xe//B9VE4hnOkktWqnJDHQKFaWdEsi+Pa8YEtDFVswslt5KzdZAFZQjOkOe/1xd9TtDMb9u1rkotjhkWk5f613QERLxZO54BkIRaFhAwpBEkEzRXmxI3ItIZWEb0DkQaE0W2ADqQqMynDeVNaUXfguuRYEGoYZ+hIsLFljJqFVQZxlLJ+tpzsqncNNOXP7u0zwVn4JiOzSp4INZhrcIBNtewtStXvIWxV66aK9BJrAxSFssKD4m8H1MUSC6+w827fAJ5Wv9JzP/ajiDEu1zMKrtIa9Qeey4CH/OzPGyY9rP7mAErybgPHcWi9o2PgLlGL3W+bSpcq9hNinyaJ0CElgYFg4/Tc8haPagOMvPvvhl1IDAAA=",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "410"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 22:01:45 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/Da75mVPAgAA"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_time_as_integer_success.json
+++ b/tests/mocks/dashboard_create_with_filters_time_as_integer_success.json
@@ -1,0 +1,215 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-04-16T22:11:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 22:11:27 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-16T22:11:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "[{\"name\": \"lol\", \"programText\": \"data(\\\"cpu.utilization\\\").publish()\", \"options\": {\"type\": \"TimeSeriesChart\"}}]"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "111"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSX0vDMBTF3/0UJc8+OGX/fKtugjjYQIeIiMTkrg2mzbi52ezGvrtJWu062FPp79zbnHPS/UWSMO4oN6h2IF9REaBlyW2y94rXCHgR39+Tj8saOduMeOTJIWAmco40gdIqqoLGJtOHdDl7Ya3a7DQfjuhR1rN8OPwsnlKRpqw5RBjtijKoVw3JQWU5BdJrCJrt8cBWScoDGARXtV0mEDhBPKbXv74Z9waD0XDcH7WiwejhXju7eN6lb40HJpwlUyzQrAFJQXRfOq2jKMEKVGtSJnpk9YpUVpgNYDWPSncFNlDS3KuaV11lpfRJ69Y4FN0jw12oAk7QhqPiX7od/b+QDI1bd/rtp9lfNnXEy1mbWXNLy7U839jRwF3VCaGN+K63VlxbiKzgPxPwcUNqVLJjnpW8TuN/MUtVUojw9DX4RqNuQYNncnq2N+JZm/vwC0G7ZznLAgAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "354"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 22:11:27 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-16T22:11:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"authorizedWriters\": {\"teams\": [], \"users\": []}, \"chartDensity\": \"DEFAULT\", \"charts\": [{\"chartId\": \"Da77_mKAcAA\", \"column\": 0, \"height\": 1, \"row\": 0, \"width\": 6}], \"created\": 1523916687958, \"creator\": \"ClusPSzAYAA\", \"customProperties\": null, \"description\": \"\", \"discoveryOptions\": null, \"eventOverlays\": null, \"filters\": {\"time\": {\"start\": 1523721600000, \"end\": 1523808000000}}, \"groupId\": \"Da77_m5AgAA\", \"id\": \"Da77_nLAYAA\", \"lastUpdated\": 1523916687958, \"lastUpdatedBy\": null, \"locked\": false, \"maxDelayOverride\": null, \"name\": \"testy mctesterson\", \"selectedEventOverlays\": null, \"tags\": null}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "596"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.signalfx.com/v2/dashboard/Da77_nLAYAA"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWS0U6DMBSG730K0utdjJkB8w7dTIxLtkQXY4wxtZxBY6FLe9hky97dtoCMTbkh/N857elXDleeR2iJmVR8D8mL4ghKE+/GOxhiGALN3XdRCjGos1I3NTYz0dHmhGVU4RQKzbGykExn9/Fq/kw66pre2qVd9JDUtTQMP/LHmMUxaXZhUpR5YemwSTLgaYY28ZtEyd1pwY4nmNkgsFN57/XOCiiC28Yfj64nfhBE4WQcdVAqN8OdKPXyaR+/NjMQVmqU+VLJDSjk0NNAEtBM8Q1y6WYkdUvCNZNbUNXCkX4LbKHAhaGCVn2y5uLMu5alYnBuHnkOXZFdsvg9WDSMhu4ZtFCjEdzicOQHDjt6bBbcUsXpp4DL60yVLDe92xnHaWuGn+TFvDMmqMbVJrnwHfmT6LzgtvrbupDsq25fU6HBZTn9noKxZuUpnkBPXkFrKeZf1Vh5ObNvY9NcjOMaBJgsmf2rH2naCTj+ANG8PzgUAwAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "381"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 22:11:28 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/Da77_nLAYAA"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_create_with_filters_time_as_string_success.json
+++ b/tests/mocks/dashboard_create_with_filters_time_as_string_success.json
@@ -1,0 +1,215 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-04-16T22:02:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 22:02:54 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-16T22:02:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "[{\"name\": \"lol\", \"programText\": \"data(\\\"cpu.utilization\\\").publish()\", \"options\": {\"type\": \"TimeSeriesChart\"}}]"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "111"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSUUvDMBSF3/0VJc8+rE475lvdJgjCBjpkiEhM7tpg2pTkZrMb++8mabXtYE+l37m3Oeekx6soItRirrQ4AH/TAkEbEt1HR6c4DYEW4f09+rhukDXtiEOOnDwmLKca51AagbXXyHzxmK6fX0mntjvthwN64s0snSSzzWeapSlpD2FK2qL06qglOYgsR0/ilmi17w/sBcfcg8S7auwSpoEihGPiu5vxNE7iye04mXai0sHDTFqzejmkm9YDYdagKlZaVaBRQHBfWimDyMEwLSoUKngkzQoXhqkd6HoZlOEK7KDEpVMlrYfKVsiz1o2ymg2P9HchCjhDO6oF/ZLd6P+FZFrZqt8vyC6b6PFylLI/LqnBdcUvN9YbeKgHIaRi383WlkoDgRX0Zw4urk+tBR+YJyVt0rhfzGAdFcw/XQ2u0aAbkOAYX1zsDWnW5T79Aq9hn7DLAgAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "354"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 22:02:54 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-04-16T22:02:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"authorizedWriters\": {\"teams\": [], \"users\": []}, \"chartDensity\": \"DEFAULT\", \"charts\": [{\"chartId\": \"Da76CY_AgAA\", \"column\": 0, \"height\": 1, \"row\": 0, \"width\": 6}], \"created\": 1523916174369, \"creator\": \"ClusPSzAYAA\", \"customProperties\": null, \"description\": \"\", \"discoveryOptions\": null, \"eventOverlays\": null, \"filters\": {\"time\": {\"start\": \"-1h\", \"end\": \"Now\"}}, \"groupId\": \"Da76CelAYAA\", \"id\": \"Da76Cn0AcAA\", \"lastUpdated\": 1523916174369, \"lastUpdatedBy\": null, \"locked\": false, \"maxDelayOverride\": null, \"name\": \"testy mctesterson\", \"selectedEventOverlays\": null, \"tags\": null}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "580"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://api.signalfx.com/v2/dashboard/Da76Cn0AcAA"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSUWvCMBDH3/cpSp4d2Okq7q1TB4MxhU2GjDGy5GzD0qYkV10Vv/uStFKr21PJ73+XO37p/ioICC0xVVrsgL9pgaANCe6CvU1shkAzf85LKXs1K01T45hFB8cJS6nGKeRGYOVCMp09xMunV9Kmvun9eLVHj7yupaNosvqMkzgmzRSmZJnlLu03JAWRpOhI2BCttqcFW8ExdSByWwUf9WQNFMGPCW9vBuMwCkfDQTRuQ6X9DhNZmsXLLl41OxBWGlTZQqsCNAroaCAcDNOiQKH8jqRu4cIwtQFdzX3SbYEN5Di3qaRVN1kLeebdqFIzODePIoO2yF2Z1/6erYjeERq0Yj2+DlPi6aG5YEO1oF8SLp8v0aosTl8DZGtCnPC8H7Mjl9TgsuCXfqPB8LzgvvrbslTsu25fU2nAs4z+TMFacrK04NCRldNagv03DVZBxtzX2rMP4XMDEizjs391I01aAYdfjqF2SQQDAAA=",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "374"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 16 Apr 2018 22:02:54 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/Da76Cn0AcAA"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/test_signal_analog_dashboards.py
+++ b/tests/test_signal_analog_dashboards.py
@@ -18,7 +18,7 @@ from signal_analog.errors import ResourceMatchNotFoundError, \
     ResourceHasMultipleExactMatchesError, ResourceAlreadyExistsError, \
     SignalAnalogError
 from signal_analog.flow import Data
-from signal_analog.filters import DashboardFilters, FilterVariable
+from signal_analog.filters import DashboardFilters, FilterVariable, FilterSource, FilterTime
 
 
 # Global config. This will store all recorded requests in the 'mocks' dir
@@ -519,6 +519,446 @@ def test_dashboard_create_with_filters_with_unexpected_data_type_failure():
             .with_api_token('foo')\
             .with_charts(mk_chart('lol'))\
             .with_filters(dashboard_filter)\
+            .create()
+
+
+def test_dashboard_create_with_filters_source_success():
+    aws_src = FilterSource()\
+        .with_property("aws_region")\
+        .with_value("us-west-2")
+
+    dashboard_filter = DashboardFilters()\
+        .with_sources(aws_src)
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_source_success',
+                                      serialize_with='prettyjson'):
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .with_filters(dashboard_filter)\
+            .create()
+
+
+def test_dashboard_create_with_filters_source_NOT_success():
+    aws_src = FilterSource()\
+        .with_property("aws_region")\
+        .with_value("us-west-2") \
+        .with_is_not(True)
+
+    dashboard_filter = DashboardFilters()\
+        .with_sources(aws_src)
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_source_NOT_success',
+                                      serialize_with='prettyjson'):
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .with_filters(dashboard_filter)\
+            .create()
+
+
+def test_dashboard_create_with_filters_source_with_empty_property_failure():
+    with pytest.raises(ValueError):
+        aws_src = FilterSource() \
+            .with_property("") \
+            .with_value("us-west-2")
+
+        dashboard_filter = DashboardFilters() \
+            .with_sources(aws_src)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_source_with_empty_value_failure():
+    with pytest.raises(ValueError):
+        aws_src = FilterSource() \
+            .with_property("aws_region") \
+            .with_value("")
+
+        dashboard_filter = DashboardFilters() \
+            .with_sources(aws_src)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_source_with_empty_is_not_failure():
+    with pytest.raises(ValueError):
+        aws_src = FilterSource() \
+            .with_property("aws_region") \
+            .with_value("") \
+            .with_is_not('')
+
+        dashboard_filter = DashboardFilters() \
+            .with_sources(aws_src)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_source_with_missing_property_failure():
+    with pytest.raises(ValueError):
+        aws_src = FilterSource() \
+            .with_value("us-west-2")
+
+        dashboard_filter = DashboardFilters() \
+            .with_sources(aws_src)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_source_with_missing_value_failure():
+    with pytest.raises(ValueError):
+        aws_src = FilterSource() \
+            .with_property("aws_region")
+
+        dashboard_filter = DashboardFilters() \
+            .with_sources(aws_src)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_source_with_missing_property_and_value_failure():
+    with pytest.raises(ValueError):
+        aws_src = FilterSource()
+
+        dashboard_filter = DashboardFilters() \
+            .with_sources(aws_src)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_as_string_success():
+    time = FilterTime()\
+        .with_start("-1h")\
+        .with_end("Now")
+
+    dashboard_filter = DashboardFilters()\
+        .with_time(time)
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_time_as_string_success',
+                                      serialize_with='prettyjson'):
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .with_filters(dashboard_filter)\
+            .create()
+
+
+def test_dashboard_create_with_filters_time_as_integer_success():
+    time = FilterTime()\
+        .with_start(1523721600000)\
+        .with_end(1523808000000)
+
+    dashboard_filter = DashboardFilters()\
+        .with_time(time)
+
+    with global_recorder.use_cassette('dashboard_create_with_filters_time_as_integer_success',
+                                      serialize_with='prettyjson'):
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .with_filters(dashboard_filter)\
+            .create()
+
+
+def test_dashboard_create_with_filters_time_empty_start_time_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime() \
+            .with_start('') \
+            .with_end('Now')
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_empty_end_time_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime() \
+            .with_start('-1h') \
+            .with_end('')
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_missing_start_time_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime() \
+            .with_end('Now')
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_missing_end_time_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime() \
+            .with_start('-1h')
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_missing_start_and_end_time_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_start_and_end_time_as_different_data_types_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start(1523808000000)\
+            .with_end("Now")
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_start_and_end_time_as_unsupported_data_type_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start(True)\
+            .with_end(False)
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_start_first_character_is_not_negative_sign_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start("1h")\
+            .with_end("Now")
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_start_unexpected_last_character_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start("-1z")\
+            .with_end("Now")
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_start_no_positive_integer_after_negative_sign_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start("--1h")\
+            .with_end("Now")
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_start_no_integer_after_negative_sign_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start("-zh")\
+            .with_end("Now")
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_end_time_is_not_Now_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start("-1h")\
+            .with_end("Not Now")
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_start_and_end_time_are_negative_integers_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start(-1523808000000)\
+            .with_end(-1523894400000)
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_start_time_is_negative_integer_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start(-1523808000000)\
+            .with_end(1523894400000)
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_end_time_is_negative_integer_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start(1523808000000)\
+            .with_end(-1523894400000)
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
+            .create()
+
+
+def test_dashboard_create_with_filters_time_start_time_is_not_less_than_end_time_failure():
+    with pytest.raises(ValueError):
+        time = FilterTime()\
+            .with_start(1523894400000)\
+            .with_end(1523808000000)
+
+        dashboard_filter = DashboardFilters() \
+            .with_time(time)
+
+        Dashboard(session=global_session) \
+            .with_name('testy mctesterson') \
+            .with_api_token('foo') \
+            .with_charts(mk_chart('lol')) \
+            .with_filters(dashboard_filter) \
             .create()
 
 

--- a/tests/test_signal_analog_resources.py
+++ b/tests/test_signal_analog_resources.py
@@ -61,7 +61,7 @@ def test_resource_init_api_token():
 
 def test_is_valid_without_message():
         with pytest.raises(ValueError) as error:
-                util.is_valid(None, error_message=None)
+                util.assert_valid(None, error_message=None)
                 assert error.message is None
 
 


### PR DESCRIPTION
We implemented variable filters before. This is to implement the rest of the available filters Source and Time. Here's an example:
```python
from signal_analog.flow import Data
from signal_analog.charts import TimeSeriesChart
from signal_analog.dashboards import Dashboard
from signal_analog.filters import DashboardFilters, FilterVariable, FilterSource, FilterTime

program = Data('cpu.utilization').publish()
chart = TimeSeriesChart().with_name('Sample Chart Name').with_program(program)

dashboard = Dashboard().with_name('Dashboard With Filters').with_charts(chart)

aws_src = FilterSource().with_property("aws_region").with_value('us-west-2')

time = FilterTime().with_start("-1h").with_end("Now")

app_filter = DashboardFilters() \
    .with_sources(aws_src) \
    .with_time(time)

dashboard_with_filters = dashboard.with_filters(app_filter).with_api_token(api_token).update()

print(dashboard_with_filters)

```

**Note:** This PR also fixes #20 and #25 