### PR TITLE
Add basic program validation

### DIFF
--- a/signal_analog/charts.py
+++ b/signal_analog/charts.py
@@ -7,6 +7,7 @@ import signal_analog.util as util
 from signal_analog.errors import ResourceMatchNotFoundError, \
     ResourceHasMultipleExactMatchesError, ResourceAlreadyExistsError
 from signal_analog.resources import Resource
+from signal_analog.flow import Program
 
 
 class Chart(Resource):
@@ -38,6 +39,11 @@ class Chart(Resource):
         https://developers.signalfx.com/docs/signalflow-overview
         """
         util.assert_valid(program)
+        # Chart's don't require you to use a Program object, so make a best
+        # effort to validate if we can.
+        if isinstance(program, Program):
+            program.validate()
+
         self.options.update({'programText': program})
         return self
 

--- a/signal_analog/combinators.py
+++ b/signal_analog/combinators.py
@@ -44,6 +44,7 @@ class Or(NAryCombinator):
     def __init__(self, *ns):
         super(Or, self).__init__('or', *ns)
 
+
 class LT(NAryCombinator):
 
     def __init__(self, left, right):

--- a/signal_analog/detectors.py
+++ b/signal_analog/detectors.py
@@ -9,8 +9,9 @@ from signal_analog.flow import Program
 from six import string_types
 import signal_analog.util as util
 from email_validator import validate_email
-from signal_analog.errors import ResourceMatchNotFoundError, \
-        ResourceHasMultipleExactMatchesError, ResourceAlreadyExistsError
+from signal_analog.errors import \
+    ResourceMatchNotFoundError, \
+    ResourceAlreadyExistsError
 
 
 class Notification(object):
@@ -422,6 +423,9 @@ class Detector(Resource):
             msg = 'Signal Analog Detectors only support Program objects, we' +\
                    ' got a "{0}" instead.'
             raise ValueError(msg.format(program.__class__.__name__))
+
+        if isinstance(program, Program):
+            program.validate()
 
         self.options.update({
             'programText': str(program)

--- a/signal_analog/errors.py
+++ b/signal_analog/errors.py
@@ -3,11 +3,13 @@ class SignalAnalogError(Exception):
     """Base exception for any invalid states in the Signal Analog library."""
     pass
 
+
 class ResourceMatchNotFoundError(SignalAnalogError):
     def __init__(self, resource_name):
         msg = 'Could not find an exact match for "{0}" in SignalFx.'
         super(ResourceMatchNotFoundError, self).__init__(
             msg.format(resource_name))
+
 
 class ResourceAlreadyExistsError(SignalAnalogError):
 
@@ -33,3 +35,24 @@ class ResourceHasMultipleExactMatchesError(SignalAnalogError):
         """
         super(ResourceHasMultipleExactMatchesError, self).__init__(
             error_msg.format(dashboard_name))
+
+
+class ProgramValidationError(SignalAnalogError):
+    """Base exception for an invalid program in the Signal Analog library."""
+    pass
+
+
+class ProgramDoesNotPublishTimeseriesError(ProgramValidationError):
+    def __init__(self, program):
+        str_program = '\n\t'.join(map(str, program))
+        error_msg = """
+    The following program contains no publish statements, or does not appear to
+    publish a useful timeseries.
+
+        {0}
+
+    Have you received this exception in error? File a bug at:
+    https://github.com/Nike-inc/signal_analog/issues
+""".format(str_program)
+
+        super(ProgramDoesNotPublishTimeseriesError, self).__init__(error_msg)

--- a/tests/test_signal_analog_detectors.py
+++ b/tests/test_signal_analog_detectors.py
@@ -413,22 +413,22 @@ def test_detector_with_assign_combinator():
 
     utilization_mean = Assign(mean_string, mean_data)
 
-    detect = Detect(When(GT(Ref(mean_string), 50)))
+    detect = Detect(When(GT(Ref(mean_string), 50))).publish(label='detector')
 
-    program = Program( \
-        utilization_sum, \
-        utilization_count, \
-        utilization_mean, \
-        detect \
+    program = Program(
+        utilization_sum,
+        utilization_count,
+        utilization_mean,
+        detect
     )
 
     detector = Detector().with_program(program)
 
-    assert detector.options["programText"] == "{0}\n{1}\n{2}\n{3}".format( \
-        str(utilization_sum), \
-        str(utilization_count), \
-        str(utilization_mean), \
-        str(detect) \
+    assert detector.options["programText"] == "{0}\n{1}\n{2}\n{3}".format(
+        str(utilization_sum),
+        str(utilization_count),
+        str(utilization_mean),
+        str(detect)
     )
 
     assert program.statements.pop() == detect

--- a/tests/test_signal_analog_flow.py
+++ b/tests/test_signal_analog_flow.py
@@ -3,7 +3,9 @@
 import pytest
 
 from signal_analog.flow import Program, Data, Filter, Op, When, Assign, Ref
-from signal_analog.combinators import Mul, GT
+from signal_analog.combinators import Mul, GT, Div
+from signal_analog.errors import \
+    ProgramDoesNotPublishTimeseriesError
 
 from hypothesis import given, settings
 from .generators import ascii, flows
@@ -86,3 +88,48 @@ def test_ref():
     ref = Ref(strRef)
 
     assert str(ref) == strRef
+
+
+def test_valid_publish_statements_default():
+    data = Data('requests.mean')
+
+    with pytest.raises(ProgramDoesNotPublishTimeseriesError):
+        Program(data).validate()
+
+
+def test_valid_publish_statements_happy():
+    data = Data('requests.mean').publish(label='foo')
+    Program(data).validate()
+
+
+def test_valid_publish_statements_multi():
+    Program(
+        Data('requests.mean'),
+        Data('foo').publish(label='foo')
+    ).validate()
+
+
+def test_valid_publish_statements_assign_happy():
+    Program(
+        Assign('A', Data('foo').publish(label='lol'))
+    ).validate()
+
+
+def test_valid_publish_statements_assign_invalid():
+    with pytest.raises(ProgramDoesNotPublishTimeseriesError):
+        Program(
+            Assign('A', Data('foo'))
+        ).validate()
+
+
+def test_valid_publish_statements_comb_invalid():
+    with pytest.raises(ProgramDoesNotPublishTimeseriesError):
+        Program(
+            Op(Div(Data('foo'), Data('bar')))
+        ).validate()
+
+
+def test_valid_publish_statement_comb_valid():
+    Program(
+        Op(Div(Data('foo'), Data('bar'))).publish(label='foobar')
+    ).validate()


### PR DESCRIPTION
Validate that programs publish at least one timeseries (otherwise, what
are you doing?). This can be used as an example of how to implement
program validation for more complicated use cases.