### PR TITLE
Add enum for Sfx field option mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   `with_legend_options` builder
   * Future chart types that can filter legend options may now take advantage
   of the `signal_analog.charts.LegendOptionsMixin` class
+  * The `FieldOption` class has learned to accept `SignalFxFieldOption`s which
+  provide mappings between field options seen in the UI and those used in the
+  API
+      * e.g. `Plot Name` in the UI and `sf_originatingMetric` in the API
 
 ## 2.0.0 (2018-07-24)
 

--- a/signal_analog/charts.py
+++ b/signal_analog/charts.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 from enum import Enum
+from six import string_types
 
 import signal_analog.util as util
 from signal_analog.errors import ResourceMatchNotFoundError, \
@@ -202,6 +203,23 @@ class AxisOption(ChartOption):
         }
 
 
+class SignalFxFieldOption(Enum):
+    """Common SignalFx field options intended to be combined with FieldOption.
+
+    When using these values via the API it's non-obvious how you would filter
+    them out of your charts. Using 'Plot Name' in your FieldOption would not
+    hide 'Plot Name' in the UI, you would use 'sf_originatingMetric' instead.
+    This enum is intended to make the behavior of the UI consistent with the
+    UI.
+
+    Values:
+        metric: the 'sf_metric' field option.
+        plot_name: the 'Plot Name' field option.
+    """
+    metric = 'sf_metric'
+    plot_name = 'sf_originatingMetric'
+
+
 class FieldOption(ChartOption):
     """Field options used to display columns in a chart's table."""
 
@@ -216,7 +234,17 @@ class FieldOption(ChartOption):
         if not property:
             raise ValueError('Field option cannot be blank')
 
-        self.opts = {'property': property, 'enabled': enabled}
+        if isinstance(property, SignalFxFieldOption):
+            # <insert home buying joke here>
+            value = property.value
+        elif isinstance(property, string_types):
+            value = property
+        else:
+            msg = 'FieldOption property should be a string or' +\
+                  'SignalFxFieldOption, got "{0}" instead.'
+            raise ValueError(msg.format(property))
+
+        self.opts = {'property': value, 'enabled': enabled}
 
 
 class PublishLabelOptions(ChartOption):

--- a/tests/test_signal_analog_charts.py
+++ b/tests/test_signal_analog_charts.py
@@ -1,10 +1,11 @@
 import pytest
+from enum import Enum
 
 from signal_analog.charts import Chart, TimeSeriesChart, UnitPrefix, ColorBy, \
                                  PlotType, AxisOption, FieldOption,\
                                  PublishLabelOptions, PaletteColor,\
                                  SingleValueChart, ListChart, SortBy,\
-                                 HeatmapChart
+                                 HeatmapChart, SignalFxFieldOption
 from signal_analog.flow import Data
 
 
@@ -283,3 +284,40 @@ def test_ts_list_charts_mixin():
     with pytest.raises(Exception):
         SingleValueChart().with_legend_options(FieldOption('foo', enabled=False))
 
+
+def test_sfx_field_options_enum():
+    """We expect values from the SignalFxFieldOption enum to be serialized.
+    """
+    expected = {'fields': [{'property': 'sf_originatingMetric', 'enabled': False}]}
+
+    ts = TimeSeriesChart()\
+            .with_legend_options([
+                FieldOption(SignalFxFieldOption.plot_name, enabled=False)
+            ])
+
+    assert ts.chart_options['legendOptions'] == expected
+
+
+def test_sfx_field_options_happy():
+    """We also expect that string values are still valid."""
+
+    expected = {'fields': [{'property': 'foo', 'enabled': False}]}
+
+    ts = TimeSeriesChart()\
+            .with_legend_options([FieldOption('foo', enabled=False)])
+
+    assert ts.chart_options['legendOptions'] == expected
+
+
+
+def test_sfx_field_options_invalid():
+    """Other enums should not be allowed."""
+
+    class InvalidEnum(Enum):
+        foo = 'bar'
+
+    with pytest.raises(ValueError):
+        ts = TimeSeriesChart()\
+                .with_legend_options([
+                    FieldOption(InvalidEnum.foo, enabled=False)
+                ])


### PR DESCRIPTION
Why wait for the api docs to be updated? Let's make some constants!