### PR TITLE
Refactor Dashboard and Dashboard Group create methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # History
 
+## 2.2.0 (2018-09-27)
+
+### Changed
+  * Dashboard Create method to accept group id of an existing dashboard group in which case the new dashboard will be
+   part of the dashboard group provided
+   
+   Example:
+```python
+response = dashboard\
+  .with_charts(memory_chart)\
+  .with_api_token('my-api-token')\
+  .create(group_id="asdf;lkj")
+``` 
+  * Dashboard Group create method to pass group id of the newly created dashboard group to the dashboard create 
+  method so that we can avoid  a few redundant calls like cloning and deleting the dashboards
+
 ## 2.1.0 (2018-08-21)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ At this point one of two things will happen:
   - We successfully created the dashboard, in which case the JSON response is
   returned as a dictionary.
 
+Also, if you have an existing Dashboard Group and you want this new dashboard to be part of that dashboard group, you
+ can pass that group id of the dashboard group when creating the dashboard. Something like this:
+
+```python
+response = dash\
+  .with_charts(memory_chart)\
+  .with_api_token('my-api-token')\
+  .create(group_id="asdf;lkj")
+``` 
+ 
 Now, storing API keys in source isn't ideal, so if you'd like to see how you
 can pass in your API keys at runtime check the documentation below to see how
 you can [dynamically build a CLI for your resources](#cli-builder).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.2.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ test_requirements = [
 
 setup(
     name='signal_analog',
-    version='2.1.0',
+    version='2.2.0',
     description='A troposphere-like library for managing SignalFx'
                 + 'Charts, Dashboards, and Detectors.',
     long_description=readme + '\n\n' + history,

--- a/signal_analog/__init__.py
+++ b/signal_analog/__init__.py
@@ -9,7 +9,7 @@ import os
 
 __author__ = """Fernando Freire"""
 __email__ = 'Lst-nike.plus.platform.sharedinfrastructure@nike.com'
-__version__ = '2.1.0'
+__version__ = '2.2.0'
 
 logging_config = pkg_resources.resource_string(
     __name__, 'logging.yaml').decode('utf-8')

--- a/signal_analog/dashboards.py
+++ b/signal_analog/dashboards.py
@@ -413,7 +413,7 @@ class Dashboard(Resource):
                     'height': 2,
                     'row': row_num_to_set,
                     'width': 6})
-            return state
+        return state
 
     def update(self, name=None, description=None, resource_id=None, dry_run=False):
         """Updates a Signalfx dashboard using the /dashboard/_id_ helper

--- a/tests/mocks/dashboard_create_with_dashboard_group_id_success.json
+++ b/tests/mocks/dashboard_create_with_dashboard_group_id_success.json
@@ -1,0 +1,144 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-09-26T22:11:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.19.1"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Wed, 26 Sep 2018 22:11:33 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard?name=testy+mctesterson"
+      }
+    },
+    {
+      "recorded_at": "2018-09-26T22:11:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "[{\"name\": \"lol\", \"programText\": \"data(\\\"cpu.utilization\\\").publish()\", \"options\": {\"type\": \"TimeSeriesChart\"}}]"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "111"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.19.1"
+          ],
+          "X-SF-Token": [
+            "foo"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson&groupId=DnogQGhAcAA"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHWSS0/DMBCE7/yKyGcOhHe4paQgJKQWQXkIcTD2NrFw4mhtt6RV/zu2k5KmUk9RvtmNZ8ZZH0URodYUCsUK+BsKA6hJdBOtneI0A7QM75/R13GLrO5GHHJk4zFhBUWTQaWFabxGsvFdOnt8Ib3a7XQfDuiBt7Mqe32vdJqnmnSHMCVtWXn1pCMFiLwwnsQdQbXcHVgKbgoPLr2r1i5hCNRAOCa+OLtKkuQ6OY9P415UGDzcSqunz6v0I007z1YbVU5R1YBGQHBfWSmDyEEzFLURKngk7QoXmqkFYDMJynAFFlCZiVMlbYbKXMi91rWyyIZH+rsQJeyhBUVBv2U/+n8hOSpbb/utVP50X6Rsm03s9F6P+sySajOr+eHGdgZGzSCEVOyn3ZpTqSGwkv5m4OL61Cj4wDypaJvG/WLaNFHJ/NPV4BoNugYJjvHxwd4Mzfvcmz8eKKwWywIAAA==",
+          "encoding": null
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "358"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Wed, 26 Sep 2018 22:11:34 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=testy+mctesterson&groupId=DnogQGhAcAA"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/mocks/dashboard_group_with_dashboard_create_failure_interactive.json
+++ b/tests/mocks/dashboard_group_with_dashboard_create_failure_interactive.json
@@ -220,7 +220,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIuPRuAYAE"
       },
       "response": {
         "body": {
@@ -251,7 +251,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIuPRuAYAE"
       }
     },
     {

--- a/tests/mocks/dashboard_group_with_dashboard_create_success.json
+++ b/tests/mocks/dashboard_group_with_dashboard_create_success.json
@@ -220,7 +220,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIxadgAYAE"
       },
       "response": {
         "body": {
@@ -251,7 +251,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIxadgAYAE"
       }
     },
     {

--- a/tests/mocks/dashboard_group_with_dashboard_create_success_force.json
+++ b/tests/mocks/dashboard_group_with_dashboard_create_success_force.json
@@ -220,7 +220,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIwltLAcAA"
       },
       "response": {
         "body": {
@@ -251,7 +251,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIwltLAcAA"
       }
     },
     {

--- a/tests/mocks/dashboard_group_with_dashboard_create_success_interactive.json
+++ b/tests/mocks/dashboard_group_with_dashboard_create_success_interactive.json
@@ -220,7 +220,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIvSDmAgAA"
       },
       "response": {
         "body": {
@@ -251,7 +251,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIvSDmAgAA"
       }
     },
     {

--- a/tests/mocks/dashboard_group_with_dashboard_update_success.json
+++ b/tests/mocks/dashboard_group_with_dashboard_update_success.json
@@ -344,7 +344,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DWhUtzeAgAA"
       },
       "response": {
         "body": {
@@ -375,7 +375,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DWhUtzeAgAA"
       }
     },
     {
@@ -533,7 +533,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=FalconHeavy"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=FalconHeavy&groupId=DWhUtzeAgAA"
       },
       "response": {
         "body": {
@@ -564,7 +564,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=FalconHeavy"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=FalconHeavy&groupId=DWhUtzeAgAA"
       }
     },
     {

--- a/tests/mocks/dashboard_group_with_delete_existing_dashboard_update_success.json
+++ b/tests/mocks/dashboard_group_with_delete_existing_dashboard_update_success.json
@@ -282,7 +282,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Draagoon"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Draagoon&groupId=DXIrwyaAgAE"
       },
       "response": {
         "body": {
@@ -313,7 +313,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Draagoon"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Draagoon&groupId=DXIrwyaAgAE"
       }
     },
     {

--- a/tests/test_signal_analog_dashboards.py
+++ b/tests/test_signal_analog_dashboards.py
@@ -962,6 +962,25 @@ def test_dashboard_create_with_filters_time_start_time_is_not_less_than_end_time
             .create()
 
 
+def test_dashboard_create_with_dashboard_group_id_success():
+    with global_recorder.use_cassette('dashboard_create_with_dashboard_group_id_success',
+                                      serialize_with='prettyjson'):
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .create(group_id='DnogQGhAcAA')
+
+
+def test_dashboard_create_with_invalid_dashboard_group_id_failure():
+    with pytest.raises(RuntimeError):
+        Dashboard(session=global_session)\
+            .with_name('testy mctesterson')\
+            .with_api_token('foo')\
+            .with_charts(mk_chart('lol'))\
+            .create(group_id='asdf;lkj')
+
+
 def test_dashboard_update_with_filters_success():
     app_var = FilterVariable().with_alias('app') \
         .with_property('app') \


### PR DESCRIPTION
* Dashboard Create method to accept group id of an existing dashboard group in which case the new dashboard will be
   part of the dashboard group provided
* Dashboard Group create method to pass group id of the newly created dashboard group to the dashboard create
  method so that we can avoid  a few redundant calls like cloning and deleting the dashboards

This will fix issues #63 #70 #71 