### PR TITLE
requests uses simplejson if it is available to process json

### DIFF
--- a/signal_analog/resources.py
+++ b/signal_analog/resources.py
@@ -10,9 +10,12 @@ from signal_analog.errors import ResourceMatchNotFoundError, \
 
 # py2/3 compatibility hack so that we can consistently handle JSON errors.
 try:
-    from json.decoder import JSONDecodeError
+    from simplejson.decoder import JSONDecodeError
 except ImportError:
-    JSONDecodeError = ValueError
+    try:
+        from json.decoder import JSONDecodeError
+    except ImportError:
+        JSONDecodeError = ValueError
 
 __SIGNALFX_API_ENDPOINT__ = 'https://api.signalfx.com/v2'
 


### PR DESCRIPTION
Use the same library as requests so json errors are handled correctly

https://github.com/requests/requests/blob/c501ec986daa4961cd9dee370b5d45ff2e524b37/requests/compat.py#L29