### PR TITLE
Fixed yaml loader warning on library start. 

### DIFF
--- a/signal_analog/__init__.py
+++ b/signal_analog/__init__.py
@@ -14,7 +14,8 @@ __version__ = '2.4.0'
 logging_config = pkg_resources.resource_string(
     __name__, 'logging.yaml').decode('utf-8')
 
-logging.config.dictConfig(yaml.load(logging_config))
+# Fix for yaml loader according to https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
+logging.config.dictConfig(yaml.load(logging_config, Loader=yaml.SafeLoader))
 
 logger = logging.getLogger()
 


### PR DESCRIPTION
Getting warning message about deprecated yaml method:
lib/python3.7/site-packages/signal_analog/__init__.py:17: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  logging.config.dictConfig(yaml.load(logging_config))

Fixed yaml loader warning on library start. According to https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

