### PR TITLE
Remove dashboard numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # History
 
+## 2.7.0 (2019-03-26)
+
+  * Removed dashboard numbering for two reasons:
+    1. There was a bug in the logic that caused dashboards to be deleted and recreated on update.
+    1. The functionality is no longer needed as SignalFx automatically maintains the order that dashboards were provided and allows easy reordering in the UI.
+
 ## 2.5.0 (2019-03-20)
 
   * Added `Plot` class, a helper class that gives an interface more like that found in the SignalFx UI.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.0
+current_version = 2.7.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [bumpversion]
-current_version = 2.5.0
-
+current_version = 2.6.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ test_requirements = [
 
 setup(
     name='signal_analog',
-    version='2.6.0',
+    version='2.7.0',
     description='A troposphere-like library for managing SignalFx'
                 + 'Charts, Dashboards, and Detectors.',
     long_description=readme + '\n\n' + history,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ test_requirements = [
 
 setup(
     name='signal_analog',
-    version='2.5.0',
+    version='2.6.0',
     description='A troposphere-like library for managing SignalFx'
                 + 'Charts, Dashboards, and Detectors.',
     long_description=readme + '\n\n' + history,

--- a/signal_analog/__init__.py
+++ b/signal_analog/__init__.py
@@ -9,7 +9,7 @@ import os
 
 __author__ = """Fernando Freire"""
 __email__ = 'Lst-nike.plus.platform.sharedinfrastructure@nike.com'
-__version__ = '2.6.0'
+__version__ = '2.7.0'
 
 logging_config = pkg_resources.resource_string(
     __name__, 'logging.yaml').decode('utf-8')

--- a/signal_analog/__init__.py
+++ b/signal_analog/__init__.py
@@ -9,7 +9,7 @@ import os
 
 __author__ = """Fernando Freire"""
 __email__ = 'Lst-nike.plus.platform.sharedinfrastructure@nike.com'
-__version__ = '2.5.0'
+__version__ = '2.6.0'
 
 logging_config = pkg_resources.resource_string(
     __name__, 'logging.yaml').decode('utf-8')

--- a/signal_analog/dashboards.py
+++ b/signal_analog/dashboards.py
@@ -87,7 +87,6 @@ class DashboardGroup(Resource):
             if len(self.dashboards) > 0:
                 for dashboard in self.dashboards:
                     dashboard.with_api_token(self.api_token)\
-                        .with_numbered_dashboards(self.dashboards, dashboard)\
                         .create(group_id=dashboard_group_create_response['id'], force=True)
 
                 if len(dashboard_group_create_response['dashboards']) > 0:
@@ -154,8 +153,7 @@ class DashboardGroup(Resource):
         remote_names = list(map(lambda x: x['name'], remote_dashboards))
         for local_dashboard in local_dashboards:
             if local_dashboard.__get__('name') not in remote_names:
-                resp = local_dashboard.with_numbered_dashboards(local_dashboards, local_dashboard)\
-                    .with_api_token(self.api_token)\
+                resp = local_dashboard.with_api_token(self.api_token)\
                     .create(force=True)
                 self.clone(resp['id'], state['id'])
                 self.with_id(resp['groupId']).delete()
@@ -288,18 +286,6 @@ class Dashboard(Resource):
         """Default events to display on the dashboard"""
         for selectedeventoverlay in selectedeventoverlays:
             self.selectedevents['selectedEventOverlays'].append(deepcopy(selectedeventoverlay))
-        return self
-
-    def with_numbered_dashboards(self, resourcelist, resource):
-        """Helper to number dashboards according to their index in a list.
-        Single digit numbers will be padded with a leading zero.
-
-        Arguments:
-            resourcelist: A list of dashboard resources
-            resource: The dashboard to be numbered
-        """
-        numberedname = str(resourcelist.index(resource) + 1).zfill(2) + ' - ' + resource.__get__('name')
-        self.options.update({'name': numberedname})
         return self
 
     def create(self, group_id=None, dry_run=False, force=False, interactive=False):

--- a/tests/mocks/dashboard_group_with_dashboard_create_failure_interactive.json
+++ b/tests/mocks/dashboard_group_with_dashboard_create_failure_interactive.json
@@ -155,7 +155,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       },
       "response": {
         "body": {
@@ -186,7 +186,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       }
     },
     {
@@ -220,7 +220,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Falcon99&groupId=DXIuPRuAYAE"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIuPRuAYAE"
       },
       "response": {
         "body": {
@@ -251,7 +251,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Falcon99&groupId=DXIuPRuAYAE"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIuPRuAYAE"
       }
     },
     {

--- a/tests/mocks/dashboard_group_with_dashboard_create_success.json
+++ b/tests/mocks/dashboard_group_with_dashboard_create_success.json
@@ -155,7 +155,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       },
       "response": {
         "body": {
@@ -220,7 +220,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Falcon99&groupId=DXIxadgAYAE"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIxadgAYAE"
       },
       "response": {
         "body": {

--- a/tests/mocks/dashboard_group_with_dashboard_create_success_force.json
+++ b/tests/mocks/dashboard_group_with_dashboard_create_success_force.json
@@ -155,7 +155,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       },
       "response": {
         "body": {
@@ -186,7 +186,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       }
     },
     {
@@ -220,7 +220,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Falcon99&groupId=DXIwltLAcAA"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIwltLAcAA"
       },
       "response": {
         "body": {
@@ -251,7 +251,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Falcon99&groupId=DXIwltLAcAA"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIwltLAcAA"
       }
     },
     {

--- a/tests/mocks/dashboard_group_with_dashboard_create_success_interactive.json
+++ b/tests/mocks/dashboard_group_with_dashboard_create_success_interactive.json
@@ -155,7 +155,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       },
       "response": {
         "body": {
@@ -186,7 +186,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       }
     },
     {
@@ -220,7 +220,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Falcon99&groupId=DXIvSDmAgAA"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIvSDmAgAA"
       },
       "response": {
         "body": {
@@ -251,7 +251,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Falcon99&groupId=DXIvSDmAgAA"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DXIvSDmAgAA"
       }
     },
     {

--- a/tests/mocks/dashboard_group_with_dashboard_update_success.json
+++ b/tests/mocks/dashboard_group_with_dashboard_update_success.json
@@ -217,7 +217,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       },
       "response": {
         "body": {
@@ -248,7 +248,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       }
     },
     {
@@ -279,7 +279,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "uri": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       },
       "response": {
         "body": {
@@ -310,7 +310,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard?name=01+-+Falcon99"
+        "url": "https://api.signalfx.com/v2/dashboard?name=Falcon99"
       }
     },
     {
@@ -344,7 +344,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Falcon99&groupId=DWhUtzeAgAA"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DWhUtzeAgAA"
       },
       "response": {
         "body": {
@@ -375,7 +375,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Falcon99&groupId=DWhUtzeAgAA"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Falcon99&groupId=DWhUtzeAgAA"
       }
     },
     {
@@ -406,7 +406,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.signalfx.com/v2/dashboard?name=02+-+FalconHeavy"
+        "uri": "https://api.signalfx.com/v2/dashboard?name=FalconHeavy"
       },
       "response": {
         "body": {
@@ -437,7 +437,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard?name=02+-+FalconHeavy"
+        "url": "https://api.signalfx.com/v2/dashboard?name=FalconHeavy"
       }
     },
     {
@@ -468,7 +468,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.signalfx.com/v2/dashboard?name=02+-+FalconHeavy"
+        "uri": "https://api.signalfx.com/v2/dashboard?name=FalconHeavy"
       },
       "response": {
         "body": {
@@ -499,7 +499,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard?name=02+-+FalconHeavy"
+        "url": "https://api.signalfx.com/v2/dashboard?name=FalconHeavy"
       }
     },
     {
@@ -533,7 +533,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=02+-+FalconHeavy&groupId=DWhUtzeAgAA"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=FalconHeavy&groupId=DWhUtzeAgAA"
       },
       "response": {
         "body": {
@@ -564,7 +564,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=02+-+FalconHeavy&groupId=DWhUtzeAgAA"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=FalconHeavy&groupId=DWhUtzeAgAA"
       }
     },
     {

--- a/tests/mocks/dashboard_group_with_delete_existing_dashboard_update_success.json
+++ b/tests/mocks/dashboard_group_with_delete_existing_dashboard_update_success.json
@@ -217,7 +217,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.signalfx.com/v2/dashboard?name=01+-+Draagoon"
+        "uri": "https://api.signalfx.com/v2/dashboard?name=Draagoon"
       },
       "response": {
         "body": {
@@ -248,7 +248,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard?name=01+-+Draagoon"
+        "url": "https://api.signalfx.com/v2/dashboard?name=Draagoon"
       }
     },
     {
@@ -282,7 +282,7 @@
           ]
         },
         "method": "POST",
-        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Draagoon&groupId=DXIrwyaAgAE"
+        "uri": "https://api.signalfx.com/v2/dashboard/simple?name=Draagoon&groupId=DXIrwyaAgAE"
       },
       "response": {
         "body": {
@@ -313,7 +313,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.signalfx.com/v2/dashboard/simple?name=01+-+Draagoon&groupId=DXIrwyaAgAE"
+        "url": "https://api.signalfx.com/v2/dashboard/simple?name=Draagoon&groupId=DXIrwyaAgAE"
       }
     },
     {


### PR DESCRIPTION
Removed dashboard numbering for two reasons:

1.  There was a bug in the logic that caused dashboards to be deleted and recreated on update.
2. The functionality is no longer needed as SignalFx automatically maintains the order that dashboards were provided and allows easy reordering in the UI.  (Announced Jan 11, 2019)