### PR TITLE
Added groupBy and colorscale2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased Changes
+
+* Added `groupBy` support to the chart options. Allows grouping for example of HeatMap charts into groups on multiple levels.
+* Added support for `colorScale2` option on HeatMap charts. This allows to set custom chart colors for a defined range of values.
+
 ## 2.7.2 (2019-05-14)
 
 ### Fixed

--- a/signal_analog/charts.py
+++ b/signal_analog/charts.py
@@ -787,6 +787,16 @@ class HeatmapChart(Chart, DisplayOptionsMixin):
         self.chart_options.update({'colorScale': opts})
         return self
 
+    def with_colorscale2(self, thresholds):
+        """List of secondary visualization properties
+
+        Arguments:
+            thresholds: The thresholds to set for the color range being used.
+        """
+        util.assert_valid(thresholds)
+        self.chart_options.update({'colorScale2': thresholds})
+        return self
+
 
 class TextChart(Chart, DisplayOptionsMixin):
 

--- a/signal_analog/charts.py
+++ b/signal_analog/charts.py
@@ -791,7 +791,12 @@ class HeatmapChart(Chart, DisplayOptionsMixin):
         """List of secondary visualization properties
 
         Arguments:
-            thresholds: The thresholds to set for the color range being used.
+            thresholds: Ranges for which each color will be applied. Ex.
+                [
+                    {"gte": 80, "paletteIndex": 16},
+                    {"gt": 50, "lt": 80, "paletteIndex": 18},
+                    {"lte": 50, "paletteIndex": 20},
+                ]
         """
         util.assert_valid(thresholds)
         self.chart_options.update({'colorScale2': thresholds})

--- a/signal_analog/charts.py
+++ b/signal_analog/charts.py
@@ -405,6 +405,16 @@ class DisplayOptionsMixin(object):
         self.chart_options.update({'sortBy': sort_by.value})
         return self
 
+    def with_group_by(self, group_by):
+        """Determine how values are grouped.
+
+        Arguments:
+            group_by: List of strings that defines how we group values. Ex. ['role', 'instance-id']
+        """
+        util.assert_valid(group_by)
+        self.chart_options.update({'groupBy': group_by})
+        return self
+
     def with_unit_prefix(self, prefix):
         """Add a unit prefix to this chart.
 

--- a/tests/test_signal_analog_charts.py
+++ b/tests/test_signal_analog_charts.py
@@ -309,6 +309,16 @@ def test_hm_chart_with_colorscale():
     chart = HeatmapChart().with_colorscale([70, 50])
     assert chart.chart_options['colorScale'] == opts
 
+def test_hm_chart_with_colorscale2():
+    opts = [{"gte": 80, "paletteIndex": 16},{"gt": 50, "lt": 80, "paletteIndex": 18}]
+    chart = HeatmapChart().with_colorscale2(opts)
+    assert chart.chart_options['colorScale2'] == opts
+
+def test_hm_chart_with_group_by():
+    opts = ['item-1', 'item-2']
+    chart = HeatmapChart().with_group_by(opts)
+    assert chart.chart_options['groupBy'] == opts
+
 def test_ts_list_charts_mixin():
     """TimeSeries and ListCharts can set legend options. But not others."""
 


### PR DESCRIPTION
Added groupBy options for the charts and the colorscale2 option which is used on heatmaps.

API Docs: https://developers.signalfx.com/charts_reference.html#operation/Create%20Single%20Chart

