### PR TITLE
Fix/dne resource deletes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.0
+current_version = 2.9.1.dev0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.1.dev0
+current_version = 2.9.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ test_requirements = [
 
 setup(
     name='signal_analog',
-    version='2.9.1.dev0',
+    version='2.9.1',
     description='A troposphere-like library for managing SignalFx'
                 + 'Charts, Dashboards, and Detectors.',
     long_description=readme + '\n\n' + history,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ test_requirements = [
 
 setup(
     name='signal_analog',
-    version='2.9.0',
+    version='2.9.1.dev0',
     description='A troposphere-like library for managing SignalFx'
                 + 'Charts, Dashboards, and Detectors.',
     long_description=readme + '\n\n' + history,

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     author="Fernando Freire",
     author_email='fernando.freire@nike.com',
     url='https://github.com/Nike-inc/signal_analog',
-    packages=find_packages(include=['signal_analog']),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=requirements,
     zip_safe=False,

--- a/signal_analog/__init__.py
+++ b/signal_analog/__init__.py
@@ -9,7 +9,7 @@ import os
 
 __author__ = """Fernando Freire"""
 __email__ = 'Lst-nike.plus.platform.sharedinfrastructure@nike.com'
-__version__ = '2.9.0'
+__version__ = '2.9.1.dev0'
 
 logging_config = pkg_resources.resource_string(
     __name__, 'logging.yaml').decode('utf-8')

--- a/signal_analog/__init__.py
+++ b/signal_analog/__init__.py
@@ -9,7 +9,7 @@ import os
 
 __author__ = """Fernando Freire"""
 __email__ = 'Lst-nike.plus.platform.sharedinfrastructure@nike.com'
-__version__ = '2.9.1.dev0'
+__version__ = '2.9.1'
 
 logging_config = pkg_resources.resource_string(
     __name__, 'logging.yaml').decode('utf-8')

--- a/signal_analog/error/signalfx.py
+++ b/signal_analog/error/signalfx.py
@@ -1,0 +1,29 @@
+"""Errors specific to SignalFx API interactions."""
+
+
+class SignalFxError(Exception):
+    """Base exception for any SignalFx API errors."""
+
+    pass
+
+
+class ResourceNotFound(SignalFxError):
+    """The given resource was not found in SignalFx."""
+
+    def __init__(self, endpoint):
+        msg = f"Could not find resource at endpoint '{endpoint}' in SignalFx."
+        super(ResourceNotFound, self).__init__(msg)
+
+
+class Unauthorized(SignalFxError):
+    """The given request did not successfully authenticate with SignalFx."""
+
+    def __init__(self):
+        msg = (
+            "The provided token was not able to be used to authenticate"
+            + "successfully with SignalFx. Have you made sure that:\n\t"
+            + "- The token is correct?\n\t"
+            + "- The token is active?\n\t"
+            + "- There are no extra whitespace characters in the token?"
+        )
+        super(Unauthorized, self).__init__(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,26 +4,37 @@ import betamax
 from betamax_serializers import pretty_json
 import pytest
 import requests
+import os
 
-from signal_analog.flow import Data
+from signal_analog.flow import Data, Program, Detect, Data
+from signal_analog.combinators import GT
 from signal_analog.charts import TimeSeriesChart, PlotType
 from signal_analog.dashboards import Dashboard
+from signal_analog.detectors import Detector, Rule, Severity, EmailNotification
+
+signalfx_api_token = os.environ.get("SFX_API_TOKEN", "test-token")
 
 
 with betamax.Betamax.configure() as config:
     betamax.Betamax.register_serializer(pretty_json.PrettyJSONSerializer)
-    config.cassette_library_dir = 'tests/mocks'
+    config.cassette_library_dir = "tests/mocks"
+    config.define_cassette_placeholder("<SFX_TOKEN>", signalfx_api_token)
 
 
 global_session = requests.Session()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
+def api_token():
+    return signalfx_api_token
+
+
+@pytest.fixture(scope="session")
 def session():
     return global_session
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def sfx_recorder(session):
     recorder = betamax.Betamax(session)
     return recorder
@@ -32,17 +43,45 @@ def sfx_recorder(session):
 @pytest.fixture()
 def chart(session):
     def fun(name):
-        program = Data('cpu.utilization').publish()
-        return TimeSeriesChart(session=session)\
-            .with_name(name)\
-            .with_program(program)
+        program = Data("cpu.utilization").publish()
+        return TimeSeriesChart(session=session).with_name(name).with_program(program)
+
     return fun
 
 
 @pytest.fixture()
 def dashboard(session, chart):
     def fun(dash_name, chart_name):
-        return Dashboard(session=session)\
-            .with_name(dash_name)\
+        return (
+            Dashboard(session=session)
+            .with_name(dash_name)
             .with_charts(chart(chart_name))
+        )
+
+    return fun
+
+
+@pytest.fixture()
+def detector(session, chart):
+    def fun(name, threshold):
+        program = Program(
+            Detect(GT(Data("cpu.utilization"), threshold)).publish(label=name)
+        )
+
+        rule = (
+            Rule()
+            .for_label(name)
+            .with_severity(Severity.Info)
+            .with_notifications(
+                EmailNotification("francisco.friar@polite.thoughtleader.org")
+            )
+        )
+
+        return (
+            Detector(session=session)
+            .with_name(name)
+            .with_program(program)
+            .with_rules(rule)
+        )
+
     return fun

--- a/tests/mocks/detector_delete_success.json
+++ b/tests/mocks/detector_delete_success.json
@@ -1,0 +1,373 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2019-10-30T20:31:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.22.0"
+          ],
+          "X-SF-Token": [
+            "<SFX_TOKEN>"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/detector?name=francisco_friar"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": [
+            "no-cache, no-store, must-revalidate, no-transform"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Wed, 30 Oct 2019 20:31:16 GMT"
+          ],
+          "Expires": [
+            "0"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/detector?name=francisco_friar"
+      }
+    },
+    {
+      "recorded_at": "2019-10-30T20:31:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"name\": \"francisco_friar\", \"programText\": \"detect(data(\\\"cpu.utilization\\\") > 9001).publish(label=\\\"francisco_friar\\\")\", \"rules\": [{\"detectLabel\": \"francisco_friar\", \"severity\": \"Info\", \"notifications\": [{\"type\": \"Email\", \"email\": \"francisco.friar@polite.thoughtleader.org\"}]}]}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "279"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.22.0"
+          ],
+          "X-SF-Token": [
+            "<SFX_TOKEN>"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.signalfx.com/v2/detector"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAHVTwW7bMAy95ysMnVJgCNohTbABG5ZuPXTo0GJpMRTLMNAy7XCRLYGSgiZF/n2ybKe1tx7Fx0fykU9PoyQR4N1aM+0x+8HkkK1I3idPAQmYQyjj+2fy600T8rZNCaEQOdRhIRnBYVaHz87nb6ez+XQ+m51Pn0HNNSg+K29vl/vFw2IhGtBbp8tb1gbZETbN26oZWslkHOkqkhsGxTbi8urrFm/UQnaVFKSovqPVyteMWKnySrWgdfcme33IFwkXu/+PqrTcNPQclMUYK+HxCyrY9ZpVUGIskTNUkqzUv3Mm4KaM3iJ/u1teU0muX8yA3ECBS4OScpJwlNEqN6wLhvIOHyMx7MehdOMwNIxXQho/CcoV7SNxJU6Sj8m709Ozk4nxqSK7HscVfVgN5wqpTQP2CtvbtgYYnKCTmHTNr+uKr2qt08hCqgZrq3ekXV9j17J23c40+7ssgVRbKcQxPnvNJrHZJ6NVsO4kGNkXa6cQMuSJ5kJE6uFoXgNhf2HwaPcLne0Gonr40qd/gsRBCvsq1Xpzz2oAWAyHJdeY56rKdbcCR6ZLHR2HEQ6Klz/rn68WaCXudYU9a23JeuhOfGN6Rh8d/gJhDVvI0AMAAA==",
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": [
+            "no-cache, no-store, must-revalidate, no-transform"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "472"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Wed, 30 Oct 2019 20:31:16 GMT"
+          ],
+          "Expires": [
+            "0"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/detector"
+      }
+    },
+    {
+      "recorded_at": "2019-10-30T20:31:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.22.0"
+          ],
+          "X-SF-Token": [
+            "<SFX_TOKEN>"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/detector?name=francisco_friar"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAH1T22rbQBB991eIfXIgGKc4dlpIqdPmISUlIU4ooS5ltBrJW4+0y15M7OB/72p1cWS11ZvOmds5O/M6iCLGpSssiz5EZ6flr0bjyJoS+BG9esRj4OxKarHD5LsWFnVgK86zFiGv43+eNqAzdZgHA7avKMY1gsUkNDyfvZtMZ5PZdHo+eUtLXdLsMzlzv9jNn+dz1tDOWJnfa6lQW4HVIG3tBA3XQlkhi1CgyRKhHbu++brBO5rzQz2CGOkBjSRXZnWFpRoKLgyXv1ItIMw0Hfuvo4fA2CeV9DVdzC76IVfbfykjyddViRTIYI3m8PIFCUJW4YhquIAcQ6HjEWteblB/e1zcilzY45IK+BoyXCjkIhUcWt2tXUrLTEP+iC8h2dtqkduhFwDDJePKjbxZJHYhdclOoo/R+/H47GSkXEzCrIbB1cvl8XQ+tGmhHWFnx/qvd5AbNSPclnX/o7sMFAZi6hlZeiZtV++hdbnEW1U5ep2DoLaeZzAAnaaj0PSTkuSvYeRvw2UrSwgJ6pHUGauT92/uQYF31IsIV3Qlk21PYidi4eLfXnAvSLsilnL9pKlHGfSPLmy1YDdFKg+mWKGa8EFnMGYh657uX67Zp+e4kwUeLeFGGAfNGtyp1te6jW8y2P8BCm05jGIEAAA=",
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": [
+            "no-cache, no-store, must-revalidate, no-transform"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "503"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Wed, 30 Oct 2019 20:31:19 GMT"
+          ],
+          "Expires": [
+            "0"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/detector?name=francisco_friar"
+      }
+    },
+    {
+      "recorded_at": "2019-10-30T20:31:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.22.0"
+          ],
+          "X-SF-Token": [
+            "<SFX_TOKEN>"
+          ]
+        },
+        "method": "DELETE",
+        "uri": "https://api.signalfx.com/v2/detector/EIJveOlAcAA"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": [
+            "no-cache, no-store, must-revalidate, no-transform"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Date": [
+            "Wed, 30 Oct 2019 20:31:20 GMT"
+          ],
+          "Expires": [
+            "0"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "url": "https://api.signalfx.com/v2/detector/EIJveOlAcAA"
+      }
+    },
+    {
+      "recorded_at": "2019-10-30T20:31:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.22.0"
+          ],
+          "X-SF-Token": [
+            "<SFX_TOKEN>"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.signalfx.com/v2/detector?name=francisco_friar"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAKvmUlBQSs4vzStRUrBSMNABcYtSi0tzSopBAtEKsVy1APL4sYckAAAA",
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": [
+            "no-cache, no-store, must-revalidate, no-transform"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "51"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Wed, 30 Oct 2019 20:31:23 GMT"
+          ],
+          "Expires": [
+            "0"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=7776000"
+          ],
+          "Vary": [
+            "Accept-Encoding, User-Agent"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.signalfx.com/v2/detector?name=francisco_friar"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/test_signal_analog_dashboards.py
+++ b/tests/test_signal_analog_dashboards.py
@@ -18,6 +18,8 @@ from signal_analog.errors import ResourceMatchNotFoundError, \
     SignalAnalogError
 from signal_analog.filters import DashboardFilters, FilterVariable, FilterSource, FilterTime
 
+import signal_analog.error.signalfx as sfxerr
+
 
 # Method to capture stdout
 @contextmanager
@@ -948,7 +950,7 @@ def test_dashboard_create_with_dashboard_group_id_success(sfx_recorder, session,
 
 
 def test_dashboard_create_with_invalid_dashboard_group_id_failure(session, chart):
-    with pytest.raises(RuntimeError):
+    with pytest.raises(sfxerr.SignalFxError):
         Dashboard(session=session)\
             .with_name('testy mctesterson')\
             .with_api_token('foo')\

--- a/tests/test_signal_analog_detectors.py
+++ b/tests/test_signal_analog_detectors.py
@@ -3,6 +3,7 @@
 import re
 import pytest
 import requests
+import time
 
 from email_validator import EmailNotValidError
 from signal_analog.combinators import Div, GT, LT
@@ -478,7 +479,6 @@ def test_detector_update(sfx_recorder, session):
             .with_rules(rule)
 
         create_response = detector(90).with_api_token(api_token).create()
-        import time
         time.sleep(3)
         update_response = detector(99).with_api_token(api_token).update()
 
@@ -486,3 +486,23 @@ def test_detector_update(sfx_recorder, session):
         assert '90' in create_response['programText']
         assert '99' in update_response['programText']
         assert create_response['id'] == update_response['id']
+
+
+def test_detector_delete_not_found(sfx_recorder, api_token, detector):
+
+    with sfx_recorder.use_cassette('detector_delete_success',
+                                   serialize_with='prettyjson'):
+
+        haskell_curry = detector('francisco_friar', 9001).with_api_token(api_token)
+        tim_curry_lol = detector('francisco_friar', 9001).with_api_token(api_token)
+
+        create_response = haskell_curry.create()
+        time.sleep(3)
+        delete_response = haskell_curry.delete()
+        time.sleep(3)
+        # TODO something should happen here, empty response I think
+        second_delete_response = tim_curry_lol.delete()
+
+        assert '9001' in create_response['programText']
+        assert delete_response is None
+        assert second_delete_response is None

--- a/tests/test_signal_analog_resources.py
+++ b/tests/test_signal_analog_resources.py
@@ -8,6 +8,8 @@ from signal_analog.dashboards import Dashboard
 import signal_analog.util as util
 import json
 
+import signal_analog.error.signalfx as sfxerr
+
 
 bad_str_inputs = [None, ""]
 
@@ -86,7 +88,7 @@ def test_resource_create_error():
                 resource = Resource().with_api_token('test')
                 resource.options = {'opt': 'val'}
 
-                with pytest.raises(RuntimeError):
+                with pytest.raises(sfxerr.SignalFxError):
                         resource.create()
 
 


### PR DESCRIPTION
It turns out that if you tried to delete something that didn't exist, and you you were using the CLI builder with lots of resources, the first delete would throw an exception and fail to delete the rest.

This is Poor User Experience™, we should treat the deletion of a non-existent resource the same as a noop. We'll log whenever we tried to do something like this.